### PR TITLE
Use comma separation to make paper more readable

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -12067,455 +12067,455 @@ You can find some introduction on these on these projects:
 
 # References:
 
-[^1]: English translation of German Telemedia Act <https://www.huntonprivacyblog.com/wp-content/uploads/sites/28/2016/02/Telemedia_Act__TMA_.pdf> <sup>[[Archive.org]][747]</sup>. Section 13, Article 6, "The service provider must enable the use of Telemedia and payment for them to occur anonymously or via a pseudonym where this is technically possible and reasonable. The recipient of the service is to be informed about this possibility. ".
+[^1]: English translation of German Telemedia Act, <https://www.huntonprivacyblog.com/wp-content/uploads/sites/28/2016/02/Telemedia_Act__TMA_.pdf> <sup>[[Archive.org]][747]</sup>. Section 13, Article 6, "The service provider must enable the use of Telemedia and payment for them to occur anonymously or via a pseudonym where this is technically possible and reasonable. The recipient of the service is to be informed about this possibility. ".
 
-[^2]: Wikipedia, Real-Name System Germany <https://en.wikipedia.org/wiki/Real-name_system#Germany> <sup>[[Wikiless]][415]</sup> <sup>[[Archive.org]][416]</sup>
+[^2]: Wikipedia, Real-Name System Germany, <https://en.wikipedia.org/wiki/Real-name_system#Germany> <sup>[[Wikiless]][415]</sup> <sup>[[Archive.org]][416]</sup>
 
-[^3]: Wikipedia, Don't be evil <https://en.wikipedia.org/wiki/Don%27t_be_evil> <sup>[[Wikiless]][748]</sup> <sup>[[Archive.org]][749]</sup>
+[^3]: Wikipedia, Don't be evil, <https://en.wikipedia.org/wiki/Don%27t_be_evil> <sup>[[Wikiless]][748]</sup> <sup>[[Archive.org]][749]</sup>
 
-[^4]: YouTube, WarGames - "The Only Winning Move" <https://www.youtube.com/watch?v=6DGNZnfKYnU> <sup>[[Invidious]][750]</sup>
+[^4]: YouTube, WarGames - "The Only Winning Move", <https://www.youtube.com/watch?v=6DGNZnfKYnU> <sup>[[Invidious]][750]</sup>
 
-[^5]: Wikipedia, OSINT <https://en.wikipedia.org/wiki/Open-source_intelligence> <sup>[[Wikiless]][751]</sup> <sup>[[Archive.org]][752]</sup>
+[^5]: Wikipedia, OSINT, <https://en.wikipedia.org/wiki/Open-source_intelligence> <sup>[[Wikiless]][751]</sup> <sup>[[Archive.org]][752]</sup>
 
-[^6]: YouTube Internet Historian Playlist, HWNDU <https://www.youtube.com/playlist?list=PLna1KTNJu3y09Tu70U6yPn28sekaNhOMY> <sup>[[Invidious]][753]</sup>
+[^6]: YouTube Internet Historian Playlist, HWNDU, <https://www.youtube.com/playlist?list=PLna1KTNJu3y09Tu70U6yPn28sekaNhOMY> <sup>[[Invidious]][753]</sup>
 
-[^7]: Wikipedia, 4chan <https://en.wikipedia.org/wiki/4chan> <sup>[[Wikiless]][754]</sup> <sup>[[Archive.org]][755]</sup>
+[^7]: Wikipedia, 4chan, <https://en.wikipedia.org/wiki/4chan> <sup>[[Wikiless]][754]</sup> <sup>[[Archive.org]][755]</sup>
 
-[^8]: PIA, See this good article on the matter <https://www.privateinternetaccess.com/blog/how-does-privacy-differ-from-anonymity-and-why-are-both-important/> <sup>[[Archive.org]][756]</sup> (disclaimer: this is not an endorsement or recommendation for this commercial service).
+[^8]: PIA, See this good article on the matter, <https://www.privateinternetaccess.com/blog/how-does-privacy-differ-from-anonymity-and-why-are-both-important/> <sup>[[Archive.org]][756]</sup> (disclaimer: this is not an endorsement or recommendation for this commercial service).
 
-[^9]: Medium.com, Privacy, Blockchain and Onion Routing <https://medium.com/unitychain/privacy-blockchain-and-onion-routing-d5609c611841> <sup>[[Scribe.rip]][757]</sup> <sup>[[Archive.org]][758]</sup>
+[^9]: Medium.com, Privacy, Blockchain and Onion Routing, <https://medium.com/unitychain/privacy-blockchain-and-onion-routing-d5609c611841> <sup>[[Scribe.rip]][757]</sup> <sup>[[Archive.org]][758]</sup>
 
-[^10]: This World of Ours, James Mickens <https://scholar.harvard.edu/files/mickens/files/thisworldofours.pdf> <sup>[[Archive.org]][759]</sup>
+[^10]: This World of Ours, James Mickens, <https://scholar.harvard.edu/files/mickens/files/thisworldofours.pdf> <sup>[[Archive.org]][759]</sup>
 
-[^11]: XKCD, Security <https://xkcd.com/538/> <sup>[[Archive.org]][760]</sup>
+[^11]: XKCD, Security, <https://xkcd.com/538/> <sup>[[Archive.org]][760]</sup>
 
-[^12]: Wikipedia, Threat Model <https://en.wikipedia.org/wiki/Threat_model> <sup>[[Wikiless]][761]</sup> <sup>[[Archive.org]][762]</sup>
+[^12]: Wikipedia, Threat Model, <https://en.wikipedia.org/wiki/Threat_model> <sup>[[Wikiless]][761]</sup> <sup>[[Archive.org]][762]</sup>
 
-[^13]: Bellingcat <https://www.bellingcat.com/> <sup>[[Archive.org]][763]</sup>
+[^13]: Bellingcat, <https://www.bellingcat.com/> <sup>[[Archive.org]][763]</sup>
 
-[^14]: Wikipedia, Doxing <https://en.wikipedia.org/wiki/Doxing> <sup>[[Wikiless]][764]</sup> <sup>[[Archive.org]][765]</sup>
+[^14]: Wikipedia, Doxing, <https://en.wikipedia.org/wiki/Doxing> <sup>[[Wikiless]][764]</sup> <sup>[[Archive.org]][765]</sup>
 
-[^15]: YouTube, Internet Historian, The Bikelock Fugitive of Berkeley <https://www.youtube.com/watch?v=muoR8Td44UE> <sup>[[Invidious]][766]</sup>
+[^15]: YouTube, Internet Historian, The Bikelock Fugitive of Berkeley, <https://www.youtube.com/watch?v=muoR8Td44UE> <sup>[[Invidious]][766]</sup>
 
-[^16]: BBC News, Tor Mirror <https://www.bbc.com/news/technology-50150981> <sup>[[Archive.org]][767]</sup>
+[^16]: BBC News, Tor Mirror, <https://www.bbc.com/news/technology-50150981> <sup>[[Archive.org]][767]</sup>
 
-[^17]: GitHub, Real World Onion websites <https://github.com/alecmuffett/real-world-onion-sites> <sup>[[Archive.org]][768]</sup> (updated extremely often)
+[^17]: GitHub, Real World Onion websites, <https://github.com/alecmuffett/real-world-onion-sites> <sup>[[Archive.org]][768]</sup> (updated extremely often)
 
-[^18]: Tor Project, Who Uses Tor <https://2019.www.torproject.org/about/torusers.html.en> <sup>[[Archive.org]][769]</sup>
+[^18]: Tor Project, Who Uses Tor, <https://2019.www.torproject.org/about/torusers.html.en> <sup>[[Archive.org]][769]</sup>
 
-[^19]: Whonix Documentation, The importance of Anonymity <https://www.whonix.org/wiki/Anonymity> <sup>[[Archive.org]][770]</sup>
+[^19]: Whonix Documentation, The importance of Anonymity, <https://www.whonix.org/wiki/Anonymity> <sup>[[Archive.org]][770]</sup>
 
-[^20]: Geek Feminism <https://geekfeminism.wikia.org/wiki/Who_is_harmed_by_a_%22Real_Names%22_policy%3F> <sup>[[Archive.org]][771]</sup>
+[^20]: Geek Feminism, <https://geekfeminism.wikia.org/wiki/Who_is_harmed_by_a_%22Real_Names%22_policy%3F> <sup>[[Archive.org]][771]</sup>
 
-[^21]: Tor Project, Tor Users <https://2019.www.torproject.org/about/torusers.html.en> <sup>[[Archive.org]][769]</sup>
+[^21]: Tor Project, Tor Users, <https://2019.www.torproject.org/about/torusers.html.en> <sup>[[Archive.org]][769]</sup>
 
-[^22]: PrivacyHub, Internet Privacy in the Age of Surveillance <https://www.cyberghostvpn.com/privacyhub/internet-privacy-surveillance/> <sup>[[Archive.org]][772]</sup>
+[^22]: PrivacyHub, Internet Privacy in the Age of Surveillance, <https://www.cyberghostvpn.com/privacyhub/internet-privacy-surveillance/> <sup>[[Archive.org]][772]</sup>
 
-[^23]: PIA Blog, 50 Key Stats About Freedom of the Internet Around the World <https://www.privateinternetaccess.com/blog/internet-freedom-around-the-world-in-50-stats/> <sup>[[Archive.org]][773]</sup>
+[^23]: PIA Blog, 50 Key Stats About Freedom of the Internet Around the World, <https://www.privateinternetaccess.com/blog/internet-freedom-around-the-world-in-50-stats/> <sup>[[Archive.org]][773]</sup>
 
-[^24]: Wikipedia, IANAL <https://en.wikipedia.org/wiki/IANAL> <sup>[[Wikiless]][774]</sup> <sup>[[Archive.org]][775]</sup>
+[^24]: Wikipedia, IANAL, <https://en.wikipedia.org/wiki/IANAL> <sup>[[Wikiless]][774]</sup> <sup>[[Archive.org]][775]</sup>
 
-[^25]: Wikipedia, Trust but verify <https://en.wikipedia.org/wiki/Trust,_but_verify> <sup>[[Wikiless]][776]</sup> <sup>[[Archive.org]][777]</sup>
+[^25]: Wikipedia, Trust but verify, <https://en.wikipedia.org/wiki/Trust,_but_verify> <sup>[[Wikiless]][776]</sup> <sup>[[Archive.org]][777]</sup>
 
-[^26]: Wikipedia, IP Address <https://en.wikipedia.org/wiki/IP_address> <sup>[[Wikiless]][778]</sup> <sup>[[Archive.org]][779]</sup>
+[^26]: Wikipedia, IP Address, <https://en.wikipedia.org/wiki/IP_address> <sup>[[Wikiless]][778]</sup> <sup>[[Archive.org]][779]</sup>
 
-[^27]: Wikipedia; Data Retention <https://en.wikipedia.org/wiki/Data_retention> <sup>[[Wikiless]][780]</sup> <sup>[[Archive.org]][781]</sup>
+[^27]: Wikipedia; Data Retention, <https://en.wikipedia.org/wiki/Data_retention> <sup>[[Wikiless]][780]</sup> <sup>[[Archive.org]][781]</sup>
 
-[^28]: Wikipedia, Tor Anonymity Network <https://en.wikipedia.org/wiki/Tor_(anonymity_network)> <sup>[[Wikiless]][782]</sup> <sup>[[Archive.org]][783]</sup>
+[^28]: Wikipedia, Tor Anonymity Network, <https://en.wikipedia.org/wiki/Tor_(anonymity_network)> <sup>[[Wikiless]][782]</sup> <sup>[[Archive.org]][783]</sup>
 
-[^29]: Wikipedia, VPN <https://en.wikipedia.org/wiki/Virtual_private_network> <sup>[[Wikiless]][784]</sup> <sup>[[Archive.org]][785]</sup>
+[^29]: Wikipedia, VPN, <https://en.wikipedia.org/wiki/Virtual_private_network> <sup>[[Wikiless]][784]</sup> <sup>[[Archive.org]][785]</sup>
 
-[^30]: Ieee.org, Anonymity Trilemma: Strong Anonymity, Low Bandwidth Overhead, Low Latency - Choose Two <https://ieeexplore.ieee.org/document/8418599> <sup>[[Archive.org]][786]</sup>
+[^30]: Ieee.org, Anonymity Trilemma: Strong Anonymity, Low Bandwidth Overhead, Low Latency - Choose Two, <https://ieeexplore.ieee.org/document/8418599> <sup>[[Archive.org]][786]</sup>
 
-[^31]: Wikipedia, DNS <https://en.wikipedia.org/wiki/Domain_Name_System> <sup>[[Wikiless]][787]</sup> <sup>[[Archive.org]][788]</sup>
+[^31]: Wikipedia, DNS, <https://en.wikipedia.org/wiki/Domain_Name_System> <sup>[[Wikiless]][787]</sup> <sup>[[Archive.org]][788]</sup>
 
-[^32]: Wikipedia, DNS Blocking <https://en.wikipedia.org/wiki/DNS_blocking> <sup>[[Wikiless]][789]</sup> <sup>[[Archive.org]][790]</sup>
+[^32]: Wikipedia, DNS Blocking, <https://en.wikipedia.org/wiki/DNS_blocking> <sup>[[Wikiless]][789]</sup> <sup>[[Archive.org]][790]</sup>
 
-[^33]: CensoredPlanet <https://censoredplanet.org/> <sup>[[Archive.org]][791]</sup>
+[^33]: CensoredPlanet, <https://censoredplanet.org/> <sup>[[Archive.org]][791]</sup>
 
-[^34]: ArXiv, Characterizing Smart Home IoT Traffic in the Wild <https://arxiv.org/pdf/2001.08288.pdf> <sup>[[Archive.org]][792]</sup>
+[^34]: ArXiv, Characterizing Smart Home IoT Traffic in the Wild, <https://arxiv.org/pdf/2001.08288.pdf> <sup>[[Archive.org]][792]</sup>
 
-[^35]: Labzilla.io, Your Smart TV is probably ignoring your Pi-Hole <https://labzilla.io/blog/force-dns-pihole> <sup>[[Archive.org]][793]</sup>
+[^35]: Labzilla.io, Your Smart TV is probably ignoring your Pi-Hole, <https://labzilla.io/blog/force-dns-pihole> <sup>[[Archive.org]][793]</sup>
 
-[^36]: Wikipedia, DNS over HTTPS: <https://en.wikipedia.org/wiki/DNS_over_HTTPS> <sup>[[Wikiless]][794]</sup> <sup>[[Archive.org]][795]</sup>
+[^36]: Wikipedia, DNS over HTTPS:, <https://en.wikipedia.org/wiki/DNS_over_HTTPS> <sup>[[Wikiless]][794]</sup> <sup>[[Archive.org]][795]</sup>
 
-[^37]: Wikipedia, DNS over TLS, <https://en.wikipedia.org/wiki/DNS_over_TLS> <sup>[[Wikiless]][796]</sup> <sup>[[Archive.org]][797]</sup>
+[^37]: Wikipedia, DNS over TLS,, <https://en.wikipedia.org/wiki/DNS_over_TLS> <sup>[[Wikiless]][796]</sup> <sup>[[Archive.org]][797]</sup>
 
-[^38]: Wikipedia, Pi-Hole <https://en.wikipedia.org/wiki/Pi-hole> <sup>[[Wikiless]][798]</sup> <sup>[[Archive.org]][799]</sup>
+[^38]: Wikipedia, Pi-Hole, <https://en.wikipedia.org/wiki/Pi-hole> <sup>[[Wikiless]][798]</sup> <sup>[[Archive.org]][799]</sup>
 
-[^39]: Wikipedia, SNI <https://en.wikipedia.org/wiki/Server_Name_Indication> <sup>[[Wikiless]][800]</sup> <sup>[[Archive.org]][801]</sup>
+[^39]: Wikipedia, SNI, <https://en.wikipedia.org/wiki/Server_Name_Indication> <sup>[[Wikiless]][800]</sup> <sup>[[Archive.org]][801]</sup>
 
-[^40]: Wikipedia, ECH <https://en.wikipedia.org/wiki/Server_Name_Indication#Encrypted_Client_Hello> <sup>[[Wikiless]][800]</sup> <sup>[[Archive.org]][801]</sup>
+[^40]: Wikipedia, ECH, <https://en.wikipedia.org/wiki/Server_Name_Indication#Encrypted_Client_Hello> <sup>[[Wikiless]][800]</sup> <sup>[[Archive.org]][801]</sup>
 
-[^41]: Wikipedia, eSNI <https://en.wikipedia.org/wiki/Server_Name_Indication#Encrypted_Client_Hello> <sup>[[Wikiless]][800]</sup> <sup>[[Archive.org]][801]</sup>
+[^41]: Wikipedia, eSNI, <https://en.wikipedia.org/wiki/Server_Name_Indication#Encrypted_Client_Hello> <sup>[[Wikiless]][800]</sup> <sup>[[Archive.org]][801]</sup>
 
-[^42]: Usenix.org, On the Importance of Encrypted-SNI (ESNI) to Censorship Circumvention <https://www.usenix.org/system/files/foci19-paper_chai_0.pdf> <sup>[[Archive.org]][802]</sup>
+[^42]: Usenix.org, On the Importance of Encrypted-SNI (ESNI) to Censorship Circumvention, <https://www.usenix.org/system/files/foci19-paper_chai_0.pdf> <sup>[[Archive.org]][802]</sup>
 
-[^43]: Wikipedia, CDN <https://en.wikipedia.org/wiki/Content_delivery_network> <sup>[[Wikiless]][803]</sup> <sup>[[Archive.org]][804]</sup>
+[^43]: Wikipedia, CDN, <https://en.wikipedia.org/wiki/Content_delivery_network> <sup>[[Wikiless]][803]</sup> <sup>[[Archive.org]][804]</sup>
 
-[^44]: Cloudflare, Good-bye ESNI, hello ECH! <https://blog.cloudflare.com/encrypted-client-hello/> <sup>[[Archive.org]][805]</sup>
+[^44]: Cloudflare, Good-bye ESNI, hello ECH!, <https://blog.cloudflare.com/encrypted-client-hello/> <sup>[[Archive.org]][805]</sup>
 
-[^45]: ZDNET, Russia wants to ban the use of secure protocols such as TLS 1.3, DoH, DoT, ESNI <https://www.zdnet.com/article/russia-wants-to-ban-the-use-of-secure-protocols-such-as-tls-1-3-doh-dot-esni/> <sup>[[Archive.org]][806]</sup>
+[^45]: ZDNET, Russia wants to ban the use of secure protocols such as TLS 1.3, DoH, DoT, ESNI, <https://www.zdnet.com/article/russia-wants-to-ban-the-use-of-secure-protocols-such-as-tls-1-3-doh-dot-esni/> <sup>[[Archive.org]][806]</sup>
 
-[^46]: ZDNET, China is now blocking all encrypted HTTPS traffic that uses TLS 1.3 and ESNI <https://www.zdnet.com/article/china-is-now-blocking-all-encrypted-https-traffic-using-tls-1-3-and-esni/> <sup>[[Archive.org]][807]</sup>
+[^46]: ZDNET, China is now blocking all encrypted HTTPS traffic that uses TLS 1.3 and ESNI, <https://www.zdnet.com/article/china-is-now-blocking-all-encrypted-https-traffic-using-tls-1-3-and-esni/> <sup>[[Archive.org]][807]</sup>
 
-[^47]: Wikipedia, OCSP <https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol> <sup>[[Wikiless]][808]</sup> <sup>[[Archive.org]][809]</sup>
+[^47]: Wikipedia, OCSP, <https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol> <sup>[[Wikiless]][808]</sup> <sup>[[Archive.org]][809]</sup>
 
-[^48]: Madaidans Insecurities, Why encrypted DNS is ineffective <https://madaidans-insecurities.github.io/encrypted-dns.html> <sup>[[Archive.org]][810]</sup>
+[^48]: Madaidans Insecurities, Why encrypted DNS is ineffective, <https://madaidans-insecurities.github.io/encrypted-dns.html> <sup>[[Archive.org]][810]</sup>
 
-[^49]: Wikipedia, OCSP Stapling <https://en.wikipedia.org/wiki/OCSP_stapling> <sup>[[Wikiless]][811]</sup> <sup>[[Archive.org]][812]</sup>
+[^49]: Wikipedia, OCSP Stapling, <https://en.wikipedia.org/wiki/OCSP_stapling> <sup>[[Wikiless]][811]</sup> <sup>[[Archive.org]][812]</sup>
 
-[^50]: Chromium Documentation, CRLSets <https://dev.chromium.org/Home/chromium-security/crlsets> <sup>[[Archive.org]][813]</sup>
+[^50]: Chromium Documentation, CRLSets, <https://dev.chromium.org/Home/chromium-security/crlsets> <sup>[[Archive.org]][813]</sup>
 
-[^51]: ZDNet, Chrome does certificate revocation better <https://www.zdnet.com/article/chrome-does-certificate-revocation-better/> <sup>[[Archive.org]][814]</sup>
+[^51]: ZDNet, Chrome does certificate revocation better, <https://www.zdnet.com/article/chrome-does-certificate-revocation-better/> <sup>[[Archive.org]][814]</sup>
 
-[^52]: KUL, Encrypted DNS=⇒Privacy? A Traffic Analysis Perspective <https://www.esat.kuleuven.be/cosic/publications/article-3153.pdf> <sup>[[Archive.org]][815]</sup>
+[^52]: KUL, Encrypted DNS=⇒Privacy? A Traffic Analysis Perspective, <https://www.esat.kuleuven.be/cosic/publications/article-3153.pdf> <sup>[[Archive.org]][815]</sup>
 
-[^53]: ResearchGate, Oblivious DNS: Practical Privacy for DNS Queries <https://www.researchgate.net/publication/332893422_Oblivious_DNS_Practical_Privacy_for_DNS_Queries> <sup>[[Archive.org]][816]</sup>
+[^53]: ResearchGate, Oblivious DNS: Practical Privacy for DNS Queries, <https://www.researchgate.net/publication/332893422_Oblivious_DNS_Practical_Privacy_for_DNS_Queries> <sup>[[Archive.org]][816]</sup>
 
-[^54]: Nymity.ch, The Effect of DNS on Tor's Anonymity <https://nymity.ch/tor-dns/> <sup>[[Archive.org]][817]</sup>
+[^54]: Nymity.ch, The Effect of DNS on Tor's Anonymity, <https://nymity.ch/tor-dns/> <sup>[[Archive.org]][817]</sup>
 
-[^55]: Wikipedia, RFID <https://en.wikipedia.org/wiki/Radio-frequency_identification> <sup>[[Wikiless]][58]</sup> <sup>[[Archive.org]][59]</sup>
+[^55]: Wikipedia, RFID, <https://en.wikipedia.org/wiki/Radio-frequency_identification> <sup>[[Wikiless]][58]</sup> <sup>[[Archive.org]][59]</sup>
 
-[^56]: Wikipedia, NFC <https://en.wikipedia.org/wiki/Near-field_communication> <sup>[[Wikiless]][818]</sup> <sup>[[Archive.org]][819]</sup>
+[^56]: Wikipedia, NFC, <https://en.wikipedia.org/wiki/Near-field_communication> <sup>[[Wikiless]][818]</sup> <sup>[[Archive.org]][819]</sup>
 
-[^57]: Samsonite Online Shop, RFID accessories <https://shop.samsonite.com/accessories/rfid-accessories/> <sup>[[Archive.org]][820]</sup>
+[^57]: Samsonite Online Shop, RFID accessories, <https://shop.samsonite.com/accessories/rfid-accessories/> <sup>[[Archive.org]][820]</sup>
 
-[^58]: Google Android Help, Android Location Services <https://support.google.com/accounts/answer/3467281?hl=en> <sup>[[Archive.org]][821]</sup>
+[^58]: Google Android Help, Android Location Services, <https://support.google.com/accounts/answer/3467281?hl=en> <sup>[[Archive.org]][821]</sup>
 
-[^59]: Apple Support, Location Services and Privacy <https://support.apple.com/en-us/HT207056> <sup>[[Archive.org]][822]</sup>
+[^59]: Apple Support, Location Services and Privacy, <https://support.apple.com/en-us/HT207056> <sup>[[Archive.org]][822]</sup>
 
 [^60]: 2016 International Conference on Indoor Positioning and Indoor Navigation, Wi-Fi probes as digital crumbs for crowd localization <http://fly.isti.cnr.it/pub/papers/pdf/Wifi-probes-IPIN16.pdf> <sup>[[Archive.org]][823]</sup>
 
-[^61]: Southeast University of Nanjing, Probe Request Based Device Identification Attack and Defense <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7472341/> <sup>[[Archive.org]][824]</sup>
+[^61]: Southeast University of Nanjing, Probe Request Based Device Identification Attack and Defense, <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7472341/> <sup>[[Archive.org]][824]</sup>
 
-[^62]: Medium.com, The Perils of Probe Requests <https://medium.com/@brannondorsey/wi-fi-is-broken-3f6054210fa5> <sup>[[Scribe.rip]][825]</sup> <sup>[[Archive.org]][826]</sup>
+[^62]: Medium.com, The Perils of Probe Requests, <https://medium.com/@brannondorsey/wi-fi-is-broken-3f6054210fa5> <sup>[[Scribe.rip]][825]</sup> <sup>[[Archive.org]][826]</sup>
 
-[^63]: State University of New York, Towards 3D Human Pose Construction Using Wi-Fi <https://cse.buffalo.edu/~lusu/papers/MobiCom2020.pdf> <sup>[[Archive.org]][827]</sup>
+[^63]: State University of New York, Towards 3D Human Pose Construction Using Wi-Fi, <https://cse.buffalo.edu/~lusu/papers/MobiCom2020.pdf> <sup>[[Archive.org]][827]</sup>
 
-[^64]: Digi.Ninja, Jasager <https://digi.ninja/jasager/> <sup>[[Archive.org]][828]</sup>
+[^64]: Digi.Ninja, Jasager, <https://digi.ninja/jasager/> <sup>[[Archive.org]][828]</sup>
 
-[^65]: Hak5 Shop, Wi-Fi Pineapple <https://shop.hak5.org/products/wifi-pineapple> <sup>[[Archive.org]][829]</sup>
+[^65]: Hak5 Shop, Wi-Fi Pineapple, <https://shop.hak5.org/products/wifi-pineapple> <sup>[[Archive.org]][829]</sup>
 
-[^66]: Wikipedia, Deautentication Attack <https://en.wikipedia.org/wiki/Wi-Fi_deauthentication_attack> <sup>[[Wikiless]][830]</sup> <sup>[[Archive.org]][831]</sup>
+[^66]: Wikipedia, Deautentication Attack, <https://en.wikipedia.org/wiki/Wi-Fi_deauthentication_attack> <sup>[[Wikiless]][830]</sup> <sup>[[Archive.org]][831]</sup>
 
-[^67]: Wikipedia, Capture Portal <https://en.wikipedia.org/wiki/Captive_portal> <sup>[[Wikiless]][832]</sup> <sup>[[Archive.org]][833]</sup>
+[^67]: Wikipedia, Capture Portal, <https://en.wikipedia.org/wiki/Captive_portal> <sup>[[Wikiless]][832]</sup> <sup>[[Archive.org]][833]</sup>
 
-[^68]: HackerFactor Blog, Deanonymizing Tor Circuits <https://www.hackerfactor.com/blog/index.php?/archives/868-Deanonymizing-Tor-Circuits.html> <sup>[[Archive.org]][834]</sup>
+[^68]: HackerFactor Blog, Deanonymizing Tor Circuits, <https://www.hackerfactor.com/blog/index.php?/archives/868-Deanonymizing-Tor-Circuits.html> <sup>[[Archive.org]][834]</sup>
 
-[^69]: KU Leuven, Website Fingerprinting through Deep Learning <https://distrinet.cs.kuleuven.be/software/tor-wf-dl/> <sup>[[Archive.org]][835]</sup>
+[^69]: KU Leuven, Website Fingerprinting through Deep Learning, <https://distrinet.cs.kuleuven.be/software/tor-wf-dl/> <sup>[[Archive.org]][835]</sup>
 
-[^70]: KU Leuven, Deep Fingerprinting: Undermining Website Fingerprinting Defenses with Deep Learning <https://homes.esat.kuleuven.be/~mjuarezm/index_files/pdf/ccs18.pdf> <sup>[[Archive.org]][836]</sup>
+[^70]: KU Leuven, Deep Fingerprinting: Undermining Website Fingerprinting Defenses with Deep Learning, <https://homes.esat.kuleuven.be/~mjuarezm/index_files/pdf/ccs18.pdf> <sup>[[Archive.org]][836]</sup>
 
-[^71]: Internet Society, Website Fingerprinting at Internet Scale <https://web.archive.org/web/20160617040428/https://www.internetsociety.org/sites/default/files/blogs-media/website-fingerprinting-internet-scale.pdf> <sup>[[Archive.org]][837]</sup>
+[^71]: Internet Society, Website Fingerprinting at Internet Scale, <https://web.archive.org/web/20160617040428/https://www.internetsociety.org/sites/default/files/blogs-media/website-fingerprinting-internet-scale.pdf> <sup>[[Archive.org]][837]</sup>
 
-[^72]: KU Leuven, A Critical Evaluation of Website Fingerprinting Attacks <https://www.esat.kuleuven.be/cosic/publications/article-2456.pdf> <sup>[[Archive.org]][838]</sup>
+[^72]: KU Leuven, A Critical Evaluation of Website Fingerprinting Attacks, <https://www.esat.kuleuven.be/cosic/publications/article-2456.pdf> <sup>[[Archive.org]][838]</sup>
 
-[^73]: DailyDot, How Tor helped catch the Harvard bomb threat suspect <https://www.dailydot.com/unclick/tor-harvard-bomb-suspect/> <sup>[[Archive.org]][839]</sup>
+[^73]: DailyDot, How Tor helped catch the Harvard bomb threat suspect, <https://www.dailydot.com/unclick/tor-harvard-bomb-suspect/> <sup>[[Archive.org]][839]</sup>
 
-[^74]: ArsTechnica, How the NSA can break trillions of encrypted Web and VPN connections <https://arstechnica.com/information-technology/2015/10/how-the-nsa-can-break-trillions-of-encrypted-web-and-vpn-connections/> <sup>[[Archive.org]][840]</sup>
+[^74]: ArsTechnica, How the NSA can break trillions of encrypted Web and VPN connections, <https://arstechnica.com/information-technology/2015/10/how-the-nsa-can-break-trillions-of-encrypted-web-and-vpn-connections/> <sup>[[Archive.org]][840]</sup>
 
-[^75]: Wikipedia, Sybil Attack <https://en.wikipedia.org/wiki/Sybil_attack> <sup>[[Wikiless]][841]</sup> <sup>[[Archive.org]][842]</sup>
+[^75]: Wikipedia, Sybil Attack, <https://en.wikipedia.org/wiki/Sybil_attack> <sup>[[Wikiless]][841]</sup> <sup>[[Archive.org]][842]</sup>
 
-[^76]: ArsTechnica, Does Tor provide more benefit or harm? New paper says it depends <https://arstechnica.com/gadgets/2020/11/does-tor-provide-more-benefit-or-harm-new-paper-says-it-depends/> <sup>[[Archive.org]][843]</sup>
+[^76]: ArsTechnica, Does Tor provide more benefit or harm? New paper says it depends, <https://arstechnica.com/gadgets/2020/11/does-tor-provide-more-benefit-or-harm-new-paper-says-it-depends/> <sup>[[Archive.org]][843]</sup>
 
-[^77]: ResearchGate, The potential harms of the Tor anonymity network cluster disproportionately in free countries <https://www.pnas.org/content/early/2020/11/24/2011893117> <sup>[[Archive.org]][844]</sup>
+[^77]: ResearchGate, The potential harms of the Tor anonymity network cluster disproportionately in free countries, <https://www.pnas.org/content/early/2020/11/24/2011893117> <sup>[[Archive.org]][844]</sup>
 
-[^78]: CryptoEngineering, How does Apple (privately) find your offline devices? <https://blog.cryptographyengineering.com/2019/06/05/how-does-apple-privately-find-your-offline-devices/> <sup>[[Archive.org]][845]</sup>
+[^78]: CryptoEngineering, How does Apple (privately) find your offline devices?, <https://blog.cryptographyengineering.com/2019/06/05/how-does-apple-privately-find-your-offline-devices/> <sup>[[Archive.org]][845]</sup>
 
-[^79]: Apple Support <https://support.apple.com/en-us/HT210515> <sup>[[Archive.org]][846]</sup>
+[^79]: Apple Support, <https://support.apple.com/en-us/HT210515> <sup>[[Archive.org]][846]</sup>
 
-[^80]: XDA, Samsung's Find My Mobile app can locate Galaxy devices even when they're offline <https://www.xda-developers.com/samsung-find-my-mobile-app-locate-galaxy-devices-offline/> <sup>[[Archive.org]][847]</sup>
+[^80]: XDA, Samsung's Find My Mobile app can locate Galaxy devices even when they're offline, <https://www.xda-developers.com/samsung-find-my-mobile-app-locate-galaxy-devices-offline/> <sup>[[Archive.org]][847]</sup>
 
-[^81]: Apple Support, If your Mac is lost or stolen <https://support.apple.com/en-us/HT204756> <sup>[[Archive.org]][848]</sup>
+[^81]: Apple Support, If your Mac is lost or stolen, <https://support.apple.com/en-us/HT204756> <sup>[[Archive.org]][848]</sup>
 
-[^82]: Wikipedia, BLE <https://en.wikipedia.org/wiki/Bluetooth_Low_Energy> <sup>[[Wikiless]][849]</sup> <sup>[[Archive.org]][850]</sup>
+[^82]: Wikipedia, BLE, <https://en.wikipedia.org/wiki/Bluetooth_Low_Energy> <sup>[[Wikiless]][849]</sup> <sup>[[Archive.org]][850]</sup>
 
-[^83]: Cryptography Engineering Blog, How does Apple (privately) find your offline devices? <https://blog.cryptographyengineering.com/2019/06/05/how-does-apple-privately-find-your-offline-devices/> <sup>[[Archive.org]][845]</sup>
+[^83]: Cryptography Engineering Blog, How does Apple (privately) find your offline devices?, <https://blog.cryptographyengineering.com/2019/06/05/how-does-apple-privately-find-your-offline-devices/> <sup>[[Archive.org]][845]</sup>
 
-[^84]: Wikipedia, IMEI <https://en.wikipedia.org/wiki/International_Mobile_Equipment_Identity> <sup>[[Wikiless]][851]</sup> <sup>[[Archive.org]][852]</sup>
+[^84]: Wikipedia, IMEI, <https://en.wikipedia.org/wiki/International_Mobile_Equipment_Identity> <sup>[[Wikiless]][851]</sup> <sup>[[Archive.org]][852]</sup>
 
-[^85]: Wikipedia, IMSI <https://en.wikipedia.org/wiki/International_mobile_subscriber_identity> <sup>[[Wikiless]][853]</sup> <sup>[[Archive.org]][854]</sup>
+[^85]: Wikipedia, IMSI, <https://en.wikipedia.org/wiki/International_mobile_subscriber_identity> <sup>[[Wikiless]][853]</sup> <sup>[[Archive.org]][854]</sup>
 
-[^86]: Android Documentation, Device Identifiers <https://source.android.com/devices/tech/config/device-identifiers> <sup>[[Archive.org]][855]</sup>
+[^86]: Android Documentation, Device Identifiers, <https://source.android.com/devices/tech/config/device-identifiers> <sup>[[Archive.org]][855]</sup>
 
-[^87]: Google Privacy Policy, Look for IMEI <https://policies.google.com/privacy/embedded?hl=en-US> <sup>[[Archive.org]][856]</sup>
+[^87]: Google Privacy Policy, Look for IMEI, <https://policies.google.com/privacy/embedded?hl=en-US> <sup>[[Archive.org]][856]</sup>
 
-[^88]: Wikipedia, IMEI and the Law <https://en.wikipedia.org/wiki/International_Mobile_Equipment_Identity#IMEI_and_the_law> <sup>[[Wikiless]][851]</sup> <sup>[[Archive.org]][852]</sup>
+[^88]: Wikipedia, IMEI and the Law, <https://en.wikipedia.org/wiki/International_Mobile_Equipment_Identity#IMEI_and_the_law> <sup>[[Wikiless]][851]</sup> <sup>[[Archive.org]][852]</sup>
 
-[^89]: Bellingcat, The GRU Globetrotters: Mission London <https://www.bellingcat.com/news/uk-and-europe/2019/06/28/the-gru-globetrotters-mission-london/> <sup>[[Archive.org]][857]</sup>
+[^89]: Bellingcat, The GRU Globetrotters: Mission London, <https://www.bellingcat.com/news/uk-and-europe/2019/06/28/the-gru-globetrotters-mission-london/> <sup>[[Archive.org]][857]</sup>
 
-[^90]: Bellingcat,"V" For "Vympel": FSB's Secretive Department "V" Behind Assassination Of Georgian Asylum Seeker In Germany <https://www.bellingcat.com/news/uk-and-europe/2020/02/17/v-like-vympel-fsbs-secretive-department-v-behind-assassination-of-zelimkhan-khangoshvili/> <sup>[[Archive.org]][858]</sup>
+[^90]: Bellingcat,"V" For "Vympel": FSB's Secretive Department "V" Behind Assassination Of Georgian Asylum Seeker In Germany, <https://www.bellingcat.com/news/uk-and-europe/2020/02/17/v-like-vympel-fsbs-secretive-department-v-behind-assassination-of-zelimkhan-khangoshvili/> <sup>[[Archive.org]][858]</sup>
 
-[^91]: Wikipedia, CCTV <https://en.wikipedia.org/wiki/Closed-circuit_television> <sup>[[Wikiless]][859]</sup> <sup>[[Archive.org]][860]</sup>
+[^91]: Wikipedia, CCTV, <https://en.wikipedia.org/wiki/Closed-circuit_television> <sup>[[Wikiless]][859]</sup> <sup>[[Archive.org]][860]</sup>
 
-[^92]: Apple, Transparency Report, Device Requests <https://www.apple.com/legal/transparency/device-requests.html> <sup>[[Archive.org]][861]</sup>
+[^92]: Apple, Transparency Report, Device Requests, <https://www.apple.com/legal/transparency/device-requests.html> <sup>[[Archive.org]][861]</sup>
 
-[^93]: The Intercept, How Cops Can Secretly Track Your Phone <https://theintercept.com/2020/07/31/protests-surveillance-stingrays-dirtboxes-phone-tracking/> <sup>[[Tor Mirror]][862]</sup> <sup>[[Archive.org]][863]</sup>
+[^93]: The Intercept, How Cops Can Secretly Track Your Phone, <https://theintercept.com/2020/07/31/protests-surveillance-stingrays-dirtboxes-phone-tracking/> <sup>[[Tor Mirror]][862]</sup> <sup>[[Archive.org]][863]</sup>
 
-[^94]: Wikipedia, IMSI Catcher <https://en.wikipedia.org/wiki/IMSI-catcher> <sup>[[Wikiless]][864]</sup> <sup>[[Archive.org]][865]</sup>
+[^94]: Wikipedia, IMSI Catcher, <https://en.wikipedia.org/wiki/IMSI-catcher> <sup>[[Wikiless]][864]</sup> <sup>[[Archive.org]][865]</sup>
 
-[^95]: Wikipedia, Stingray <https://en.wikipedia.org/wiki/Stingray_phone_tracker> <sup>[[Wikiless]][866]</sup> <sup>[[Archive.org]][867]</sup>
+[^95]: Wikipedia, Stingray, <https://en.wikipedia.org/wiki/Stingray_phone_tracker> <sup>[[Wikiless]][866]</sup> <sup>[[Archive.org]][867]</sup>
 
-[^96]: Gizmodo, Cops Turn to Canadian Phone-Tracking Firm After Infamous 'Stingrays' Become 'Obsolete' <https://gizmodo.com/american-cops-turns-to-canadian-phone-tracking-firm-aft-1845442778> <sup>[[Archive.org]][868]</sup>
+[^96]: Gizmodo, Cops Turn to Canadian Phone-Tracking Firm After Infamous 'Stingrays' Become 'Obsolete', <https://gizmodo.com/american-cops-turns-to-canadian-phone-tracking-firm-aft-1845442778> <sup>[[Archive.org]][868]</sup>
 
-[^97]: Wikipedia, MITM <https://en.wikipedia.org/wiki/Man-in-the-middle_attack> <sup>[[Wikiless]][869]</sup> <sup>[[Archive.org]][870]</sup>
+[^97]: Wikipedia, MITM, <https://en.wikipedia.org/wiki/Man-in-the-middle_attack> <sup>[[Wikiless]][869]</sup> <sup>[[Archive.org]][870]</sup>
 
-[^98]: Purism, Librem 5 <https://shop.puri.sm/shop/librem-5/> <sup>[[Archive.org]][871]</sup>
+[^98]: Purism, Librem 5, <https://shop.puri.sm/shop/librem-5/> <sup>[[Archive.org]][871]</sup>
 
-[^99]: Wikipedia, MAC Address <https://en.wikipedia.org/wiki/MAC_address> <sup>[[Wikiless]][872]</sup> <sup>[[Archive.org]][873]</sup>
+[^99]: Wikipedia, MAC Address, <https://en.wikipedia.org/wiki/MAC_address> <sup>[[Wikiless]][872]</sup> <sup>[[Archive.org]][873]</sup>
 
 [^100]: Acyclica Road Trend Product Sheet, <https://web.archive.org/web/https://amsignalinc.com/data-sheets/Acyclica/Acyclica-RoadTrend-Product-Sheet.pdf> <sup>[[Archive.org]][874]</sup>
 
-[^101]: ResearchGate, Tracking Anonymized Bluetooth Devices <https://www.researchgate.net/publication/334590931_Tracking_Anonymized_Bluetooth_Devices/fulltext/5d3308db92851cd04675a469/Tracking-Anonymized-Bluetooth-Devices.pdf> <sup>[[Archive.org]][875]</sup>
+[^101]: ResearchGate, Tracking Anonymized Bluetooth Devices, <https://www.researchgate.net/publication/334590931_Tracking_Anonymized_Bluetooth_Devices/fulltext/5d3308db92851cd04675a469/Tracking-Anonymized-Bluetooth-Devices.pdf> <sup>[[Archive.org]][875]</sup>
 
-[^102]: Wikipedia, CPU <https://en.wikipedia.org/wiki/Central_processing_unit> <sup>[[Wikiless]][876]</sup> <sup>[[Archive.org]][877]</sup>
+[^102]: Wikipedia, CPU, <https://en.wikipedia.org/wiki/Central_processing_unit> <sup>[[Wikiless]][876]</sup> <sup>[[Archive.org]][877]</sup>
 
-[^103]: Wikipedia, Intel Management Engine <https://en.wikipedia.org/wiki/Intel_Management_Engine> <sup>[[Wikiless]][878]</sup> <sup>[[Archive.org]][879]</sup>
+[^103]: Wikipedia, Intel Management Engine, <https://en.wikipedia.org/wiki/Intel_Management_Engine> <sup>[[Wikiless]][878]</sup> <sup>[[Archive.org]][879]</sup>
 
-[^104]: Wikipedia, AMD Platform Security Processor <https://en.wikipedia.org/wiki/AMD_Platform_Security_Processor> <sup>[[Wikiless]][880]</sup> <sup>[[Archive.org]][881]</sup>
+[^104]: Wikipedia, AMD Platform Security Processor, <https://en.wikipedia.org/wiki/AMD_Platform_Security_Processor> <sup>[[Wikiless]][880]</sup> <sup>[[Archive.org]][881]</sup>
 
-[^105]: Wikipedia, IME, Security Vulnerabilities <https://en.wikipedia.org/wiki/Intel_Management_Engine#Security_vulnerabilities> <sup>[[Wikiless]][878]</sup> <sup>[[Archive.org]][879]</sup>
+[^105]: Wikipedia, IME, Security Vulnerabilities, <https://en.wikipedia.org/wiki/Intel_Management_Engine#Security_vulnerabilities> <sup>[[Wikiless]][878]</sup> <sup>[[Archive.org]][879]</sup>
 
-[^106]: Wikipedia, IME, Assertions that ME is a backdoor <https://en.wikipedia.org/wiki/Intel_Management_Engine#Assertions_that_ME_is_a_backdoor> <sup>[[Wikiless]][878]</sup> <sup>[[Archive.org]][879]</sup>
+[^106]: Wikipedia, IME, Assertions that ME is a backdoor, <https://en.wikipedia.org/wiki/Intel_Management_Engine#Assertions_that_ME_is_a_backdoor> <sup>[[Wikiless]][878]</sup> <sup>[[Archive.org]][879]</sup>
 
-[^107]: Wikipedia, IME, Disabling the ME <https://en.wikipedia.org/wiki/Intel_Management_Engine#Disabling_the_ME> <sup>[[Wikiless]][878]</sup> <sup>[[Archive.org]][879]</sup>
+[^107]: Wikipedia, IME, Disabling the ME, <https://en.wikipedia.org/wiki/Intel_Management_Engine#Disabling_the_ME> <sup>[[Wikiless]][878]</sup> <sup>[[Archive.org]][879]</sup>
 
 [^108]: Libreboot, <https://libreboot.org/> <sup>[[Archive.org]][882]</sup> / Coreboot, <https://www.coreboot.org/> <sup>[[Archive.org]](https://web.archive.org/web/20220501042320/https://www.coreboot.org/)</sup>
 
-[^109]: Apple, Differential Privacy White Paper <https://www.apple.com/privacy/docs/Differential_Privacy_Overview.pdf> <sup>[[Archive.org]][883]</sup>
+[^109]: Apple, Differential Privacy White Paper, <https://www.apple.com/privacy/docs/Differential_Privacy_Overview.pdf> <sup>[[Archive.org]][883]</sup>
 
-[^110]: Wikipedia, Differential Privacy <https://en.wikipedia.org/wiki/Differential_privacy> <sup>[[Wikiless]][884]</sup> <sup>[[Archive.org]][885]</sup>
+[^110]: Wikipedia, Differential Privacy, <https://en.wikipedia.org/wiki/Differential_privacy> <sup>[[Wikiless]][884]</sup> <sup>[[Archive.org]][885]</sup>
 
-[^111]: Continuing Ed, The All-Seeing "i": Apple Just Declared War on Your Privacy <https://edwardsnowden.substack.com/p/all-seeing-i> <sup>[[Archive.org]][886]</sup>
+[^111]: Continuing Ed, The All-Seeing "i": Apple Just Declared War on Your Privacy, <https://edwardsnowden.substack.com/p/all-seeing-i> <sup>[[Archive.org]][886]</sup>
 
-[^112]: Trinity College Dublin, Mobile Handset Privacy: Measuring The Data iOS and Android Send to Apple And Google <https://www.scss.tcd.ie/doug.leith/apple_google.pdf> <sup>[[Archive.org]][84]</sup>
+[^112]: Trinity College Dublin, Mobile Handset Privacy: Measuring The Data iOS and Android Send to Apple And Google, <https://www.scss.tcd.ie/doug.leith/apple_google.pdf> <sup>[[Archive.org]][84]</sup>
 
-[^113]: Reuters, Exclusive: Apple dropped plan for encrypting backups after FBI complained -- sources <https://www.reuters.com/article/us-apple-fbi-icloud-exclusive-idUSKBN1ZK1CT> <sup>[[Archive.org]][887]</sup>
+[^113]: Reuters, Exclusive: Apple dropped plan for encrypting backups after FBI complained -- sources, <https://www.reuters.com/article/us-apple-fbi-icloud-exclusive-idUSKBN1ZK1CT> <sup>[[Archive.org]][887]</sup>
 
-[^114]: ZDnet, I asked Apple for all my data. Here's what was sent back <https://www.zdnet.com/article/apple-data-collection-stored-request/> <sup>[[Archive.org]][888]</sup>
+[^114]: ZDnet, I asked Apple for all my data. Here's what was sent back, <https://www.zdnet.com/article/apple-data-collection-stored-request/> <sup>[[Archive.org]][888]</sup>
 
-[^115]: De Correspondent, Here's how we found the names and addresses of soldiers and secret agents using a simple fitness app <https://decorrespondent.nl/8481/heres-how-we-found-the-names-and-addresses-of-soldiers-and-secret-agents-using-a-simple-fitness-app/412999257-6756ba27> <sup>[[Archive.org]][889]</sup>
+[^115]: De Correspondent, Here's how we found the names and addresses of soldiers and secret agents using a simple fitness app, <https://decorrespondent.nl/8481/heres-how-we-found-the-names-and-addresses-of-soldiers-and-secret-agents-using-a-simple-fitness-app/412999257-6756ba27> <sup>[[Archive.org]][889]</sup>
 
-[^116]: Website Planet, Report: Fitness Tracker Data Breach Exposed 61 Million Records and User Data Online <https://www.websiteplanet.com/blog/gethealth-leak-report/> <sup>[[Archive.org]][890]</sup>
+[^116]: Website Planet, Report: Fitness Tracker Data Breach Exposed 61 Million Records and User Data Online, <https://www.websiteplanet.com/blog/gethealth-leak-report/> <sup>[[Archive.org]][890]</sup>
 
-[^117]: Wired, The Strava Heat Map and the End of Secrets <https://www.wired.com/story/strava-heat-map-military-bases-fitness-trackers-privacy/> <sup>[[Archive.org]][891]</sup>
+[^117]: Wired, The Strava Heat Map and the End of Secrets, <https://www.wired.com/story/strava-heat-map-military-bases-fitness-trackers-privacy/> <sup>[[Archive.org]][891]</sup>
 
-[^118]: Bellingcat, How to Use and Interpret Data from Strava's Activity Map <https://www.bellingcat.com/resources/how-tos/2018/01/29/strava-interpretation-guide/> <sup>[[Archive.org]][892]</sup>
+[^118]: Bellingcat, How to Use and Interpret Data from Strava's Activity Map, <https://www.bellingcat.com/resources/how-tos/2018/01/29/strava-interpretation-guide/> <sup>[[Archive.org]][892]</sup>
 
-[^119]: The Guardian, Fitness tracking app Strava gives away location of secret US army bases <https://www.theguardian.com/world/2018/jan/28/fitness-tracking-app-gives-away-location-of-secret-us-army-bases> <sup>[[Archive.org]][893]</sup>
+[^119]: The Guardian, Fitness tracking app Strava gives away location of secret US army bases, <https://www.theguardian.com/world/2018/jan/28/fitness-tracking-app-gives-away-location-of-secret-us-army-bases> <sup>[[Archive.org]][893]</sup>
 
-[^120]: Telegraph, Running app reveals locations of secret service agents in MI6 and GCHQ <https://www.telegraph.co.uk/technology/2018/07/08/running-app-exposes-mi6-gchq-workers-whereabouts/> <sup>[[Archive.org]][894]</sup>
+[^120]: Telegraph, Running app reveals locations of secret service agents in MI6 and GCHQ, <https://www.telegraph.co.uk/technology/2018/07/08/running-app-exposes-mi6-gchq-workers-whereabouts/> <sup>[[Archive.org]][894]</sup>
 
-[^121]: Washington Post, Alexa has been eavesdropping on you this whole time <https://www.washingtonpost.com/technology/2019/05/06/alexa-has-been-eavesdropping-you-this-whole-time/?itid=lk_interstitial_manual_59> <sup>[[Archive.org]][895]</sup>
+[^121]: Washington Post, Alexa has been eavesdropping on you this whole time, <https://www.washingtonpost.com/technology/2019/05/06/alexa-has-been-eavesdropping-you-this-whole-time/?itid=lk_interstitial_manual_59> <sup>[[Archive.org]][895]</sup>
 
-[^122]: Washington Post, What does your car know about you? We hacked a Chevy to find out <https://www.washingtonpost.com/technology/2019/12/17/what-does-your-car-know-about-you-we-hacked-chevy-find-out/> <sup>[[Archive.org]][896]</sup>
+[^122]: Washington Post, What does your car know about you? We hacked a Chevy to find out, <https://www.washingtonpost.com/technology/2019/12/17/what-does-your-car-know-about-you-we-hacked-chevy-find-out/> <sup>[[Archive.org]][896]</sup>
 
 [^123]: Using Metadata to find Paul Revere (<https://kieranhealy.org/blog/archives/2013/06/09/using-metadata-to-find-paul-revere/> <sup>[[Archive.org]][897]</sup>)
 
 [^124]: Wikipedia, Google SensorVault, <https://en.wikipedia.org/wiki/Sensorvault> <sup>[[Wikiless]][898]</sup> <sup>[[Archive.org]][899]</sup>
 
-[^125]: NRKBeta, My Phone Was Spying on Me, so I Tracked Down the Surveillants <https://nrkbeta.no/2020/12/03/my-phone-was-spying-on-me-so-i-tracked-down-the-surveillants/> <sup>[[Archive.org]][900]</sup>
+[^125]: NRKBeta, My Phone Was Spying on Me, so I Tracked Down the Surveillants, <https://nrkbeta.no/2020/12/03/my-phone-was-spying-on-me-so-i-tracked-down-the-surveillants/> <sup>[[Archive.org]][900]</sup>
 
-[^126]: New York Times <https://www.nytimes.com/interactive/2019/12/19/opinion/location-tracking-cell-phone.html> <sup>[[Archive.org]][901]</sup>
+[^126]: New York Times, <https://www.nytimes.com/interactive/2019/12/19/opinion/location-tracking-cell-phone.html> <sup>[[Archive.org]][901]</sup>
 
-[^127]: Sophos, Google data puts innocent man at the scene of a crime <https://nakedsecurity.sophos.com/2020/03/10/google-data-puts-innocent-man-at-the-scene-of-a-crime/> <sup>[[Archive.org]][902]</sup>
+[^127]: Sophos, Google data puts innocent man at the scene of a crime, <https://nakedsecurity.sophos.com/2020/03/10/google-data-puts-innocent-man-at-the-scene-of-a-crime/> <sup>[[Archive.org]][902]</sup>
 
-[^128]: Wikipedia, Geofence Warrant <https://en.wikipedia.org/wiki/Geo-fence_warrant> <sup>[[Wikiless]][903]</sup> <sup>[[Archive.org]][904]</sup>
+[^128]: Wikipedia, Geofence Warrant, <https://en.wikipedia.org/wiki/Geo-fence_warrant> <sup>[[Wikiless]][903]</sup> <sup>[[Archive.org]][904]</sup>
 
-[^129]: Vice.com, Military Unit That Conducts Drone Strikes Bought Location Data From Ordinary Apps <https://www.vice.com/en/article/y3g97x/location-data-apps-drone-strikes-iowa-national-guard> <sup>[[Archive.org]][905]</sup>
+[^129]: Vice.com, Military Unit That Conducts Drone Strikes Bought Location Data From Ordinary Apps, <https://www.vice.com/en/article/y3g97x/location-data-apps-drone-strikes-iowa-national-guard> <sup>[[Archive.org]][905]</sup>
 
-[^130]: TechCrunch, Google says geofence warrants make up one-quarter of all US demands <https://techcrunch.com/2021/08/19/google-geofence-warrants/> <sup>[[Archive.org]][906]</sup>
+[^130]: TechCrunch, Google says geofence warrants make up one-quarter of all US demands, <https://techcrunch.com/2021/08/19/google-geofence-warrants/> <sup>[[Archive.org]][906]</sup>
 
-[^131]: TechDirt, Google Report Shows 'Reverse Warrants' Are Swiftly Becoming Law Enforcement's Go-To Investigative Tool <https://www.techdirt.com/articles/20210821/10494847401/google-report-shows-reverse-warrants-are-swiftly-becoming-law-enforcements-go-to-investigative-tool.shtml> <sup>[[Archive.org]][907]</sup>
+[^131]: TechDirt, Google Report Shows 'Reverse Warrants' Are Swiftly Becoming Law Enforcement's Go-To Investigative Tool, <https://www.techdirt.com/articles/20210821/10494847401/google-report-shows-reverse-warrants-are-swiftly-becoming-law-enforcements-go-to-investigative-tool.shtml> <sup>[[Archive.org]][907]</sup>
 
-[^132]: Vice.com, Here's the FBI's Internal Guide for Getting Data from AT&T, T-Mobile, Verizon <https://www.vice.com/en/article/m7vqkv/how-fbi-gets-phone-data-att-tmobile-verizon> <sup>[[Archive.org]][908]</sup>
+[^132]: Vice.com, Here's the FBI's Internal Guide for Getting Data from AT&T, T-Mobile, Verizon, <https://www.vice.com/en/article/m7vqkv/how-fbi-gets-phone-data-att-tmobile-verizon> <sup>[[Archive.org]][908]</sup>
 
-[^133]: Wikipedia, Room 641A <https://en.wikipedia.org/wiki/Room_641A> <sup>[[Wikiless]][909]</sup> <sup>[[Archive.org]][910]</sup>
+[^133]: Wikipedia, Room 641A, <https://en.wikipedia.org/wiki/Room_641A> <sup>[[Wikiless]][909]</sup> <sup>[[Archive.org]][910]</sup>
 
-[^134]: Wikipedia, Edward Snowden <https://en.wikipedia.org/wiki/Edward_Snowden> <sup>[[Wikiless]][911]</sup> <sup>[[Archive.org]][912]</sup>
+[^134]: Wikipedia, Edward Snowden, <https://en.wikipedia.org/wiki/Edward_Snowden> <sup>[[Wikiless]][911]</sup> <sup>[[Archive.org]][912]</sup>
 
-[^135]: Wikipedia, Permanent Record <https://en.wikipedia.org/wiki/Permanent_Record_(autobiography)> <sup>[[Wikiless]][567]</sup> <sup>[[Archive.org]][568]</sup>
+[^135]: Wikipedia, Permanent Record, <https://en.wikipedia.org/wiki/Permanent_Record_(autobiography)> <sup>[[Wikiless]][567]</sup> <sup>[[Archive.org]][568]</sup>
 
-[^136]: Wikipedia, XKEYSCORE <https://en.wikipedia.org/wiki/XKeyscore> <sup>[[Wikiless]][913]</sup> <sup>[[Archive.org]][914]</sup>
+[^136]: Wikipedia, XKEYSCORE, <https://en.wikipedia.org/wiki/XKeyscore> <sup>[[Wikiless]][913]</sup> <sup>[[Archive.org]][914]</sup>
 
-[^137]: ElectroSpaces, Danish military intelligence uses XKEYSCORE to tap cables in cooperation with the NSA <https://www.electrospaces.net/2020/10/danish-military-intelligence-uses.html> <sup>[[Archive.org]][915]</sup>
+[^137]: ElectroSpaces, Danish military intelligence uses XKEYSCORE to tap cables in cooperation with the NSA, <https://www.electrospaces.net/2020/10/danish-military-intelligence-uses.html> <sup>[[Archive.org]][915]</sup>
 
-[^138]: Wikipedia, MUSCULAR <https://en.wikipedia.org/wiki/MUSCULAR_(surveillance_program)> <sup>[[Archive.org]][916]</sup>
+[^138]: Wikipedia, MUSCULAR, <https://en.wikipedia.org/wiki/MUSCULAR_(surveillance_program)> <sup>[[Archive.org]][916]</sup>
 
-[^139]: Wikipedia, SORM <https://en.wikipedia.org/wiki/SORM> <sup>[[Wikiless]][917]</sup> <sup>[[Archive.org]][918]</sup>
+[^139]: Wikipedia, SORM, <https://en.wikipedia.org/wiki/SORM> <sup>[[Wikiless]][917]</sup> <sup>[[Archive.org]][918]</sup>
 
-[^140]: Wikipedia, Tempora <https://en.wikipedia.org/wiki/Tempora> <sup>[[Wikiless]][919]</sup> <sup>[[Archive.org]][920]</sup>
+[^140]: Wikipedia, Tempora, <https://en.wikipedia.org/wiki/Tempora> <sup>[[Wikiless]][919]</sup> <sup>[[Archive.org]][920]</sup>
 
-[^141]: Wikipedia, PRISM <https://en.wikipedia.org/wiki/PRISM_(surveillance_program)> <sup>[[Wikiless]][921]</sup> <sup>[[Archive.org]][922]</sup>
+[^141]: Wikipedia, PRISM, <https://en.wikipedia.org/wiki/PRISM_(surveillance_program)> <sup>[[Wikiless]][921]</sup> <sup>[[Archive.org]][922]</sup>
 
-[^142]: Justsecurity, General Hayden <https://www.justsecurity.org/10318/video-clip-director-nsa-cia-we-kill-people-based-metadata/> <sup>[[Archive.org]][923]</sup>
+[^142]: Justsecurity, General Hayden, <https://www.justsecurity.org/10318/video-clip-director-nsa-cia-we-kill-people-based-metadata/> <sup>[[Archive.org]][923]</sup>
 
-[^143]: IDMB, The Social Dilemma <https://www.imdb.com/title/tt11464826/> <sup>[[Archive.org]][924]</sup>
+[^143]: IDMB, The Social Dilemma, <https://www.imdb.com/title/tt11464826/> <sup>[[Archive.org]][924]</sup>
 
-[^144]: ArsTechnica, How the way you type can shatter anonymity---even on Tor <https://arstechnica.com/information-technology/2015/07/how-the-way-you-type-can-shatter-anonymity-even-on-tor/> <sup>[[Archive.org]][925]</sup>
+[^144]: ArsTechnica, How the way you type can shatter anonymity---even on Tor, <https://arstechnica.com/information-technology/2015/07/how-the-way-you-type-can-shatter-anonymity-even-on-tor/> <sup>[[Archive.org]][925]</sup>
 
-[^145]: Wikipedia, Stylometry <https://en.wikipedia.org/wiki/Stylometry> <sup>[[Wikiless]][707]</sup> <sup>[[Archive.org]][926]</sup>
+[^145]: Wikipedia, Stylometry, <https://en.wikipedia.org/wiki/Stylometry> <sup>[[Wikiless]][707]</sup> <sup>[[Archive.org]][926]</sup>
 
-[^146]: Paul Moore Blog, Behavioral Profiling: The password you can't change. <https://paul.reviews/behavioral-profiling-the-password-you-cant-change/> <sup>[[Archive.org]][927]</sup>
+[^146]: Paul Moore Blog, Behavioral Profiling: The password you can't change., <https://paul.reviews/behavioral-profiling-the-password-you-cant-change/> <sup>[[Archive.org]][927]</sup>
 
-[^147]: Wikipedia, Sentiment Analysis <https://en.wikipedia.org/wiki/Sentiment_analysis> <sup>[[Wikiless]][928]</sup> <sup>[[Archive.org]][929]</sup>
+[^147]: Wikipedia, Sentiment Analysis, <https://en.wikipedia.org/wiki/Sentiment_analysis> <sup>[[Wikiless]][928]</sup> <sup>[[Archive.org]][929]</sup>
 
-[^148]: EFF, CoverYourTracks <https://coveryourtracks.eff.org/> <sup>[[Archive.org]][930]</sup>
+[^148]: EFF, CoverYourTracks, <https://coveryourtracks.eff.org/> <sup>[[Archive.org]][930]</sup>
 
-[^149]: Berkeley.edu, On the Feasibility of Internet-Scale Author Identification <https://people.eecs.berkeley.edu/~dawnsong/papers/2012%20On%20the%20Feasibility%20of%20Internet-Scale%20Author%20Identification.pdf> <sup>[[Archive.org]][931]</sup>
+[^149]: Berkeley.edu, On the Feasibility of Internet-Scale Author Identification, <https://people.eecs.berkeley.edu/~dawnsong/papers/2012%20On%20the%20Feasibility%20of%20Internet-Scale%20Author%20Identification.pdf> <sup>[[Archive.org]][931]</sup>
 
-[^150]: Forbes, Exclusive: Government Secretly Orders Google To Identify Anyone Who Searched A Sexual Assault Victim's Name, Address And Telephone Number <https://www.forbes.com/sites/thomasbrewster/2021/10/04/google-keyword-warrants-give-us-government-data-on-search-users> <sup>[[Archive.org]][932]</sup>
+[^150]: Forbes, Exclusive: Government Secretly Orders Google To Identify Anyone Who Searched A Sexual Assault Victim's Name, Address And Telephone Number, <https://www.forbes.com/sites/thomasbrewster/2021/10/04/google-keyword-warrants-give-us-government-data-on-search-users> <sup>[[Archive.org]][932]</sup>
 
-[^151]: FingerprintJS, Demo: Disabling JavaScript Won't Save You from Fingerprinting <https://fingerprintjs.com/blog/disabling-javascript-wont-stop-fingerprinting/> <sup>[[Archive.org]][933]</sup>
+[^151]: FingerprintJS, Demo: Disabling JavaScript Won't Save You from Fingerprinting, <https://fingerprintjs.com/blog/disabling-javascript-wont-stop-fingerprinting/> <sup>[[Archive.org]][933]</sup>
 
-[^152]: SecuredTouch Blog, Behavioral Biometrics 101: Behavioral Biometrics vs. Behavioral Analytics <https://blog.securedtouch.com/behavioral-biometrics-101-an-in-depth-look-at-behavioral-biometrics-vs-behavioral-analytics> <sup>[[Archive.org]][934]</sup>
+[^152]: SecuredTouch Blog, Behavioral Biometrics 101: Behavioral Biometrics vs. Behavioral Analytics, <https://blog.securedtouch.com/behavioral-biometrics-101-an-in-depth-look-at-behavioral-biometrics-vs-behavioral-analytics> <sup>[[Archive.org]][934]</sup>
 
-[^153]: ArsTechnica, Stakeout: how the FBI tracked and busted a Chicago Anon <https://arstechnica.com/tech-policy/2012/03/stakeout-how-the-fbi-tracked-and-busted-a-chicago-anon/> <sup>[[Archive.org]][935]</sup>
+[^153]: ArsTechnica, Stakeout: how the FBI tracked and busted a Chicago Anon, <https://arstechnica.com/tech-policy/2012/03/stakeout-how-the-fbi-tracked-and-busted-a-chicago-anon/> <sup>[[Archive.org]][935]</sup>
 
-[^154]: Bellingcat MH17 - Russian GRU Commander 'Orion' Identified as Oleg Ivannikov <https://www.bellingcat.com/news/uk-and-europe/2018/05/25/mh17-russian-gru-commander-orion-identified-oleg-ivannikov/> <sup>[[Archive.org]][936]</sup>
+[^154]: Bellingcat MH17 - Russian GRU Commander 'Orion' Identified as Oleg Ivannikov, <https://www.bellingcat.com/news/uk-and-europe/2018/05/25/mh17-russian-gru-commander-orion-identified-oleg-ivannikov/> <sup>[[Archive.org]][936]</sup>
 
-[^155]: Facebook Research, Deepface <https://research.fb.com/publications/deepface-closing-the-gap-to-human-level-performance-in-face-verification/> <sup>[[Archive.org]][937]</sup>
+[^155]: Facebook Research, Deepface, <https://research.fb.com/publications/deepface-closing-the-gap-to-human-level-performance-in-face-verification/> <sup>[[Archive.org]][937]</sup>
 
-[^156]: Privacy News Online, Putting the "face" in Facebook: how Mark Zuckerberg is building a world without public anonymity <https://www.privateinternetaccess.com/blog/putting-face-facebook-mark-zuckerberg-building-world-without-public-anonymity/> <sup>[[Archive.org]][938]</sup>
+[^156]: Privacy News Online, Putting the "face" in Facebook: how Mark Zuckerberg is building a world without public anonymity, <https://www.privateinternetaccess.com/blog/putting-face-facebook-mark-zuckerberg-building-world-without-public-anonymity/> <sup>[[Archive.org]][938]</sup>
 
-[^157]: CNBC, "Facebook has mapped populations in 23 countries as it explores satellites to expand internet" <https://www.cnbc.com/2017/09/01/facebook-has-mapped-human-population-building-internet-in-space.html> <sup>[[Archive.org]][939]</sup>
+[^157]: CNBC, "Facebook has mapped populations in 23 countries as it explores satellites to expand internet", <https://www.cnbc.com/2017/09/01/facebook-has-mapped-human-population-building-internet-in-space.html> <sup>[[Archive.org]][939]</sup>
 
 [^158]: MIT Technology Review, This is how we lost control of our faces, <https://www.technologyreview.com/2021/02/05/1017388/ai-deep-learning-facial-recognition-data-history/> <sup>[[Archive.org]][940]</sup>
 
-[^159]: Bellingcat, Shadow of a Doubt: Crowdsourcing Time Verification of the MH17 Missile Launch Photo <https://www.bellingcat.com/resources/case-studies/2015/08/07/shadow-of-a-doubt/> <sup>[[Archive.org]][941]</sup>
+[^159]: Bellingcat, Shadow of a Doubt: Crowdsourcing Time Verification of the MH17 Missile Launch Photo, <https://www.bellingcat.com/resources/case-studies/2015/08/07/shadow-of-a-doubt/> <sup>[[Archive.org]][941]</sup>
 
 [^160]: Brown Institute, Open-Source Investigation, <https://brown.columbia.edu/open-source-investigation/> <sup>[[Archive.org]][942]</sup>
 
-[^161]: NewScientist, Facebook can recognize you in photos even if you're not looking <https://www.newscientist.com/article/dn27761-facebook-can-recognise-you-in-photos-even-if-youre-not-looking/> <sup>[[Archive.org]][943]</sup>
+[^161]: NewScientist, Facebook can recognize you in photos even if you're not looking, <https://www.newscientist.com/article/dn27761-facebook-can-recognise-you-in-photos-even-if-youre-not-looking/> <sup>[[Archive.org]][943]</sup>
 
-[^162]: Google Patent, Techniques for emotion detection and content delivery <https://patentimages.storage.googleapis.com/2d/e4/fb/6cd2fb81899dcd/US20150242679A1.pdf> <sup>[[Archive.org]][944]</sup>
+[^162]: Google Patent, Techniques for emotion detection and content delivery, <https://patentimages.storage.googleapis.com/2d/e4/fb/6cd2fb81899dcd/US20150242679A1.pdf> <sup>[[Archive.org]][944]</sup>
 
-[^163]: APNews, Chinese 'gait recognition' tech IDs people by how they walk <https://apnews.com/article/bf75dd1c26c947b7826d270a16e2658a> <sup>[[Archive.org]][945]</sup>
+[^163]: APNews, Chinese 'gait recognition' tech IDs people by how they walk, <https://apnews.com/article/bf75dd1c26c947b7826d270a16e2658a> <sup>[[Archive.org]][945]</sup>
 
-[^164]: The Sun, New CCTV technology could now identify you just by the WAY you walk and your body shape <https://www.thesun.co.uk/news/7684204/cctv-technology-identify-body-shape-way-walk/> <sup>[[Archive.org]][946]</sup>
+[^164]: The Sun, New CCTV technology could now identify you just by the WAY you walk and your body shape, <https://www.thesun.co.uk/news/7684204/cctv-technology-identify-body-shape-way-walk/> <sup>[[Archive.org]][946]</sup>
 
-[^165]: City Security Magazine, Gait recognition: a useful identification tool <https://citysecuritymagazine.com/security-management/gait-recognition-identification-tool/> <sup>[[Archive.org]][947]</sup>
+[^165]: City Security Magazine, Gait recognition: a useful identification tool, <https://citysecuritymagazine.com/security-management/gait-recognition-identification-tool/> <sup>[[Archive.org]][947]</sup>
 
-[^166]: Vice.com, Tech Companies Are Training AI to Read Your Lips <https://www.vice.com/en/article/bvzvdw/tech-companies-are-training-ai-to-read-your-lips> <sup>[[Archive.org]][948]</sup>
+[^166]: Vice.com, Tech Companies Are Training AI to Read Your Lips, <https://www.vice.com/en/article/bvzvdw/tech-companies-are-training-ai-to-read-your-lips> <sup>[[Archive.org]][948]</sup>
 
-[^167]: New Atlas, Eye tracking can reveal an unbelievable amount of information about you <https://newatlas.com/science/science/eye-tracking-privacy/> <sup>[[Archive.org]][949]</sup>
+[^167]: New Atlas, Eye tracking can reveal an unbelievable amount of information about you, <https://newatlas.com/science/science/eye-tracking-privacy/> <sup>[[Archive.org]][949]</sup>
 
-[^168]: TechCrunch, Facial recognition reveals political party in troubling new research <https://techcrunch.com/2021/01/13/facial-recognition-reveals-political-party-in-troubling-new-research/> <sup>[[Archive.org]][950]</sup>
+[^168]: TechCrunch, Facial recognition reveals political party in troubling new research, <https://techcrunch.com/2021/01/13/facial-recognition-reveals-political-party-in-troubling-new-research/> <sup>[[Archive.org]][950]</sup>
 
-[^169]: Nature.com, Facial recognition technology can expose political orientation from naturalistic facial images <https://www.nature.com/articles/s41598-020-79310-1.pdf> <sup>[[Archive.org]][114]</sup>
+[^169]: Nature.com, Facial recognition technology can expose political orientation from naturalistic facial images, <https://www.nature.com/articles/s41598-020-79310-1.pdf> <sup>[[Archive.org]][114]</sup>
 
-[^170]: Slate <https://slate.com/technology/2018/04/facebook-collects-data-on-non-facebook-users-if-they-want-to-delete-it-they-have-to-sign-up.html> <sup>[[Archive.org]][951]</sup>
+[^170]: Slate, <https://slate.com/technology/2018/04/facebook-collects-data-on-non-facebook-users-if-they-want-to-delete-it-they-have-to-sign-up.html> <sup>[[Archive.org]][951]</sup>
 
-[^171]: The Conversation <https://theconversation.com/shadow-profiles-facebook-knows-about-you-even-if-youre-not-on-facebook-94804> <sup>[[Archive.org]][952]</sup>
+[^171]: The Conversation, <https://theconversation.com/shadow-profiles-facebook-knows-about-you-even-if-youre-not-on-facebook-94804> <sup>[[Archive.org]][952]</sup>
 
-[^172]: The Verge <https://www.theverge.com/2018/4/11/17225482/facebook-shadow-profiles-zuckerberg-congress-data-privacy> <sup>[[Archive.org]][953]</sup>
+[^172]: The Verge, <https://www.theverge.com/2018/4/11/17225482/facebook-shadow-profiles-zuckerberg-congress-data-privacy> <sup>[[Archive.org]][953]</sup>
 
-[^173]: ZDNET <https://www.zdnet.com/article/anger-mounts-after-facebooks-shadow-profiles-leak-in-bug/> <sup>[[Archive.org]][954]</sup>
+[^173]: ZDNET, <https://www.zdnet.com/article/anger-mounts-after-facebooks-shadow-profiles-leak-in-bug/> <sup>[[Archive.org]][954]</sup>
 
-[^174]: CNET <https://www.cnet.com/news/shadow-profiles-facebook-has-information-you-didnt-hand-over/> <sup>[[Archive.org]][955]</sup>
+[^174]: CNET, <https://www.cnet.com/news/shadow-profiles-facebook-has-information-you-didnt-hand-over/> <sup>[[Archive.org]][955]</sup>
 
-[^175]: Oosto <https://oosto.com/> <sup>[[Archive.org]][956]</sup>
+[^175]: Oosto, <https://oosto.com/> <sup>[[Archive.org]][956]</sup>
 
-[^176]: BuzzFeed.news, Surveillance Nation <https://www.buzzfeednews.com/article/ryanmac/clearview-ai-local-police-facial-recognition> <sup>[[Archive.org]][957]</sup>
+[^176]: BuzzFeed.news, Surveillance Nation, <https://www.buzzfeednews.com/article/ryanmac/clearview-ai-local-police-facial-recognition> <sup>[[Archive.org]][957]</sup>
 
-[^177]: Wired, Clearview AI Has New Tools to Identify You in Photos <https://www.wired.com/story/clearview-ai-new-tools-identify-you-photos/> <sup>[[Archive.org]][958]</sup>
+[^177]: Wired, Clearview AI Has New Tools to Identify You in Photos, <https://www.wired.com/story/clearview-ai-new-tools-identify-you-photos/> <sup>[[Archive.org]][958]</sup>
 
-[^178]: NEC, Neoface <https://www.nec.com/en/global/solutions/biometrics/face/neofacewatch.html> <sup>[[Archive.org]][959]</sup>
+[^178]: NEC, Neoface, <https://www.nec.com/en/global/solutions/biometrics/face/neofacewatch.html> <sup>[[Archive.org]][959]</sup>
 
-[^179]: The Guardian, Met police deploy live facial recognition technology <https://www.theguardian.com/uk-news/2020/feb/11/met-police-deploy-live-facial-recognition-technology> <sup>[[Archive.org]][960]</sup>
+[^179]: The Guardian, Met police deploy live facial recognition technology, <https://www.theguardian.com/uk-news/2020/feb/11/met-police-deploy-live-facial-recognition-technology> <sup>[[Archive.org]][960]</sup>
 
-[^180]: YouTube, The Economist, China: facial recognition and state control <https://www.youtube.com/watch?v=lH2gMNrUuEY> <sup>[[Invidious]][961]</sup>
+[^180]: YouTube, The Economist, China: facial recognition and state control, <https://www.youtube.com/watch?v=lH2gMNrUuEY> <sup>[[Invidious]][961]</sup>
 
-[^181]: CNN, Want your unemployment benefits? You may have to submit to facial recognition first <https://edition.cnn.com/2021/07/23/tech/idme-unemployment-facial-recognition/index.html> <sup>[[Archive.org]][962]</sup>
+[^181]: CNN, Want your unemployment benefits? You may have to submit to facial recognition first, <https://edition.cnn.com/2021/07/23/tech/idme-unemployment-facial-recognition/index.html> <sup>[[Archive.org]][962]</sup>
 
-[^182]: Washington Post, Huawei tested AI software that could recognize Uighur minorities and alert police, report says <https://www.washingtonpost.com/technology/2020/12/08/huawei-tested-ai-software-that-could-recognize-uighur-minorities-alert-police-report-says/> <sup>[[Archive.org]][963]</sup>
+[^182]: Washington Post, Huawei tested AI software that could recognize Uighur minorities and alert police, report says, <https://www.washingtonpost.com/technology/2020/12/08/huawei-tested-ai-software-that-could-recognize-uighur-minorities-alert-police-report-says/> <sup>[[Archive.org]][963]</sup>
 
-[^183]: The Intercept, How a Facial Recognition Mismatch Can Ruin Your Life <https://theintercept.com/2016/10/13/how-a-facial-recognition-mismatch-can-ruin-your-life/> <sup>[[Tor Mirror]][964]</sup> <sup>[[Archive.org]][965]</sup>
+[^183]: The Intercept, How a Facial Recognition Mismatch Can Ruin Your Life, <https://theintercept.com/2016/10/13/how-a-facial-recognition-mismatch-can-ruin-your-life/> <sup>[[Tor Mirror]][964]</sup> <sup>[[Archive.org]][965]</sup>
 
-[^184]: Vice, Facial Recognition Failures Are Locking People Out of Unemployment Systems <https://www.vice.com/en/article/5dbywn/facial-recognition-failures-are-locking-people-out-of-unemployment-systems> <sup>[[Archive.org]][966]</sup>
+[^184]: Vice, Facial Recognition Failures Are Locking People Out of Unemployment Systems, <https://www.vice.com/en/article/5dbywn/facial-recognition-failures-are-locking-people-out-of-unemployment-systems> <sup>[[Archive.org]][966]</sup>
 
-[^185]: BBC, WhatsApp photo drug dealer caught by 'groundbreaking' work <https://www.bbc.com/news/uk-wales-43711477> <sup>[[Archive.org]][967]</sup>
+[^185]: BBC, WhatsApp photo drug dealer caught by 'groundbreaking' work, <https://www.bbc.com/news/uk-wales-43711477> <sup>[[Archive.org]][967]</sup>
 
-[^186]: CNN, Drug dealer jailed after sharing a photo of cheese that included his fingerprints <https://edition.cnn.com/2021/05/25/uk/drug-dealer-cheese-sentenced-scli-gbr-intl/index.html> <sup>[[Archive.org]][968]</sup>
+[^186]: CNN, Drug dealer jailed after sharing a photo of cheese that included his fingerprints, <https://edition.cnn.com/2021/05/25/uk/drug-dealer-cheese-sentenced-scli-gbr-intl/index.html> <sup>[[Archive.org]][968]</sup>
 
-[^187]: Vice.com, Cops Got a Drug Dealer's Fingerprints From Photos of His Hand on WhatsApp <https://www.vice.com/en/article/evqk9e/photo-of-fingerprints-used-to-arrest-drug-dealers> <sup>[[Archive.org]][969]</sup>
+[^187]: Vice.com, Cops Got a Drug Dealer's Fingerprints From Photos of His Hand on WhatsApp, <https://www.vice.com/en/article/evqk9e/photo-of-fingerprints-used-to-arrest-drug-dealers> <sup>[[Archive.org]][969]</sup>
 
 [^188]: Kraken Blog, <https://blog.kraken.com/post/11905/your-fingerprint-can-be-hacked-for-5-heres-how/> <sup>[[Archive.org]][970]</sup>
 
-[^189]: JUSTIA Patent, Identification of taste attributes from an audio signal <https://patents.justia.com/patent/10891948> <sup>[[Archive.org]][971]</sup>
+[^189]: JUSTIA Patent, Identification of taste attributes from an audio signal, <https://patents.justia.com/patent/10891948> <sup>[[Archive.org]][971]</sup>
 
-[^190]: PYMNTS, Iris Scan Serves As Traveler ID At Dubai Airport <https://www.pymnts.com/news/biometrics/2021/iris-scan-traveler-identification-dubai-airport/> <sup>[[Archive.org]][972]</sup>
+[^190]: PYMNTS, Iris Scan Serves As Traveler ID At Dubai Airport, <https://www.pymnts.com/news/biometrics/2021/iris-scan-traveler-identification-dubai-airport/> <sup>[[Archive.org]][972]</sup>
 
 [^191]: IMDB, Gattaca 1997, <https://www.imdb.com/title/tt0119177/> <sup>[[Archive.org]][973]</sup>
 
-[^192]: IMDB, Person of Interest 2011 <https://www.imdb.com/title/tt1839578> <sup>[[Archive.org]][974]</sup>
+[^192]: IMDB, Person of Interest 2011, <https://www.imdb.com/title/tt1839578> <sup>[[Archive.org]][974]</sup>
 
 [^193]: IMDB, Minority Report 2002, <https://www.imdb.com/title/tt0181689> <sup>[[Archive.org]][975]</sup>
 
-[^194]: Wikipedia, Deepfake <https://en.wikipedia.org/wiki/Deepfake> <sup>[[Wikiless]][976]</sup> <sup>[[Archive.org]][977]</sup>
+[^194]: Wikipedia, Deepfake, <https://en.wikipedia.org/wiki/Deepfake> <sup>[[Wikiless]][976]</sup> <sup>[[Archive.org]][977]</sup>
 
-[^195]: Econotimes, Deepfake Voice Technology: The Good. The Bad. The Future <https://www.econotimes.com/Deepfake-Voice-Technology-The-Good-The-Bad-The-Future-1601278> <sup>[[Archive.org]][978]</sup>
+[^195]: Econotimes, Deepfake Voice Technology: The Good. The Bad. The Future, <https://www.econotimes.com/Deepfake-Voice-Technology-The-Good-The-Bad-The-Future-1601278> <sup>[[Archive.org]][978]</sup>
 
-[^196]: Wikipedia, Deepfake Events <https://en.wikipedia.org/wiki/Deepfake#Example_events> <sup>[[Wikiless]][976]</sup> <sup>[[Archive.org]][977]</sup>
+[^196]: Wikipedia, Deepfake Events, <https://en.wikipedia.org/wiki/Deepfake#Example_events> <sup>[[Wikiless]][976]</sup> <sup>[[Archive.org]][977]</sup>
 
-[^197]: Forbes, A Voice Deepfake Was Used To Scam A CEO Out Of $243,000 <https://www.forbes.com/sites/jessedamiani/2019/09/03/a-voice-deepfake-was-used-to-scam-a-ceo-out-of-243000/> <sup>[[Archive.org]][979]</sup>
+[^197]: Forbes, A Voice Deepfake Was Used To Scam A CEO Out Of $243,000, <https://www.forbes.com/sites/jessedamiani/2019/09/03/a-voice-deepfake-was-used-to-scam-a-ceo-out-of-243000/> <sup>[[Archive.org]][979]</sup>
 
-[^198]: Joseph Steinberg, How To Prevent Facial Recognition Technology From Identifying You <https://josephsteinberg.com/how-to-prevent-facial-recognition-technology-from-identifying-you/> <sup>[[Archive.org]][980]</sup>
+[^198]: Joseph Steinberg, How To Prevent Facial Recognition Technology From Identifying You, <https://josephsteinberg.com/how-to-prevent-facial-recognition-technology-from-identifying-you/> <sup>[[Archive.org]][980]</sup>
 
-[^199]: NIST, Face recognition accuracy with masks using pre-COVID-19 algorithms <https://nvlpubs.nist.gov/nistpubs/ir/2020/NIST.IR.8311.pdf> <sup>[[Archive.org]][981]</sup>
+[^199]: NIST, Face recognition accuracy with masks using pre-COVID-19 algorithms, <https://nvlpubs.nist.gov/nistpubs/ir/2020/NIST.IR.8311.pdf> <sup>[[Archive.org]][981]</sup>
 
-[^200]: BBC, Facial recognition identifies people wearing masks <https://www.bbc.com/news/technology-55573802> <sup>[[Archive.org]][982]</sup>
+[^200]: BBC, Facial recognition identifies people wearing masks, <https://www.bbc.com/news/technology-55573802> <sup>[[Archive.org]][982]</sup>
 
 [^201]: University of Wisconsin, Exploring Reflectacles As Anti-Surveillance Glasses and for Adversarial Machine Learning in Computer Vision <http://diglib.uwgb.edu/digital/api/collection/p17003coll4/id/71/download> <sup>[[Archive.org]][983]</sup>
 
-[^202]: Wikipedia, Phishing <https://en.wikipedia.org/wiki/Phishing> <sup>[[Wikiless]][984]</sup> <sup>[[Archive.org]][985]</sup>
+[^202]: Wikipedia, Phishing, <https://en.wikipedia.org/wiki/Phishing> <sup>[[Wikiless]][984]</sup> <sup>[[Archive.org]][985]</sup>
 
-[^203]: Wikipedia, Social Engineering <https://en.wikipedia.org/wiki/Social_engineering_(security)> <sup>[[Wikiless]][986]</sup> <sup>[[Archive.org]][987]</sup>
+[^203]: Wikipedia, Social Engineering, <https://en.wikipedia.org/wiki/Social_engineering_(security)> <sup>[[Wikiless]][986]</sup> <sup>[[Archive.org]][987]</sup>
 
-[^204]: BBC, Spy pixels in emails have become endemic <https://www.bbc.com/news/technology-56071437> <sup>[[Archive.org]][988]</sup>
+[^204]: BBC, Spy pixels in emails have become endemic, <https://www.bbc.com/news/technology-56071437> <sup>[[Archive.org]][988]</sup>
 
-[^205]: Vice, Facebook Helped the FBI Hack a Child Predator <https://www.vice.com/en/article/v7gd9b/facebook-helped-fbi-hack-child-predator-buster-hernandez> <sup>[[Archive.org]][674]</sup>
+[^205]: Vice, Facebook Helped the FBI Hack a Child Predator, <https://www.vice.com/en/article/v7gd9b/facebook-helped-fbi-hack-child-predator-buster-hernandez> <sup>[[Archive.org]][674]</sup>
 
-[^206]: Wikipedia, Exploit <https://en.wikipedia.org/wiki/Exploit_(computer_security)> <sup>[[Wikiless]][989]</sup> <sup>[[Archive.org]][990]</sup>
+[^206]: Wikipedia, Exploit, <https://en.wikipedia.org/wiki/Exploit_(computer_security)> <sup>[[Wikiless]][989]</sup> <sup>[[Archive.org]][990]</sup>
 
-[^207]: Wikipedia, Freedom Hosting <https://en.wikipedia.org/wiki/Freedom_Hosting> <sup>[[Wikiless]][991]</sup> <sup>[[Archive.org]][992]</sup>
+[^207]: Wikipedia, Freedom Hosting, <https://en.wikipedia.org/wiki/Freedom_Hosting> <sup>[[Wikiless]][991]</sup> <sup>[[Archive.org]][992]</sup>
 
-[^208]: Wired, 2013 FBI Admits It Controlled Tor Servers Behind Mass Malware Attack <https://www.wired.com/2013/09/freedom-hosting-fbi/> <sup>[[Archive.org]][993]</sup>
+[^208]: Wired, 2013 FBI Admits It Controlled Tor Servers Behind Mass Malware Attack, <https://www.wired.com/2013/09/freedom-hosting-fbi/> <sup>[[Archive.org]][993]</sup>
 
-[^209]: Wikipedia, 2020 United States federal government data breach <https://en.wikipedia.org/wiki/2020_United_States_federal_government_data_breach> <sup>[[Wikiless]][994]</sup> <sup>[[Archive.org]][995]</sup>
+[^209]: Wikipedia, 2020 United States federal government data breach, <https://en.wikipedia.org/wiki/2020_United_States_federal_government_data_breach> <sup>[[Wikiless]][994]</sup> <sup>[[Archive.org]][995]</sup>
 
-[^210]: BBC, China social media: WeChat and the Surveillance State <https://www.bbc.com/news/blogs-china-blog-48552907> <sup>[[Archive.org]][996]</sup>
+[^210]: BBC, China social media: WeChat and the Surveillance State, <https://www.bbc.com/news/blogs-china-blog-48552907> <sup>[[Archive.org]][996]</sup>
 
-[^211]: The Intercept, Revealed: Massive Chinese Police Database <https://theintercept.com/2021/01/29/china-uyghur-muslim-surveillance-police/> <sup>[[Tor Mirror]][997]</sup> <sup>[[Archive.org]][998]</sup>
+[^211]: The Intercept, Revealed: Massive Chinese Police Database, <https://theintercept.com/2021/01/29/china-uyghur-muslim-surveillance-police/> <sup>[[Tor Mirror]][997]</sup> <sup>[[Archive.org]][998]</sup>
 
-[^212]: Wikipedia, Sandbox <https://en.wikipedia.org/wiki/Sandbox_(computer_security)> <sup>[[Wikiless]][999]</sup> <sup>[[Archive.org]][1000]</sup>
+[^212]: Wikipedia, Sandbox, <https://en.wikipedia.org/wiki/Sandbox_(computer_security)> <sup>[[Wikiless]][999]</sup> <sup>[[Archive.org]][1000]</sup>
 
-[^213]: Wired, Why the Security of USB Is Fundamentally Broken <https://www.wired.com/2014/07/usb-security/> <sup>[[Archive.org]][1001]</sup>
+[^213]: Wired, Why the Security of USB Is Fundamentally Broken, <https://www.wired.com/2014/07/usb-security/> <sup>[[Archive.org]][1001]</sup>
 
-[^214]: Wikipedia, Stuxnet <https://en.wikipedia.org/wiki/Stuxnet> <sup>[[Wikiless]][1002]</sup> <sup>[[Archive.org]][1003]</sup>
+[^214]: Wikipedia, Stuxnet, <https://en.wikipedia.org/wiki/Stuxnet> <sup>[[Wikiless]][1002]</sup> <sup>[[Archive.org]][1003]</sup>
 
-[^215]: Superuser.com, How do I safely investigate a USB stick found in the parking lot at work? <https://superuser.com/questions/1206321/how-do-i-safely-investigate-a-usb-stick-found-in-the-parking-lot-at-work> <sup>[[Archive.org]][1004]</sup>
+[^215]: Superuser.com, How do I safely investigate a USB stick found in the parking lot at work?, <https://superuser.com/questions/1206321/how-do-i-safely-investigate-a-usb-stick-found-in-the-parking-lot-at-work> <sup>[[Archive.org]][1004]</sup>
 
-[^216]: The Guardian, Glenn Greenwald: how the NSA tampers with US-made internet routers <https://www.theguardian.com/books/2014/may/12/glenn-greenwald-nsa-tampers-us-internet-routers-snowden> <sup>[[Archive.org]][1005]</sup>
+[^216]: The Guardian, Glenn Greenwald: how the NSA tampers with US-made internet routers, <https://www.theguardian.com/books/2014/may/12/glenn-greenwald-nsa-tampers-us-internet-routers-snowden> <sup>[[Archive.org]][1005]</sup>
 
-[^217]: Wikipedia, Rootkit <https://en.wikipedia.org/wiki/Rootkit> <sup>[[Wikiless]][1006]</sup> <sup>[[Archive.org]][1007]</sup>
+[^217]: Wikipedia, Rootkit, <https://en.wikipedia.org/wiki/Rootkit> <sup>[[Wikiless]][1006]</sup> <sup>[[Archive.org]][1007]</sup>
 
-[^218]: Wikipedia, Userspace <https://en.wikipedia.org/wiki/User_space> <sup>[[Wikiless]][1008]</sup> <sup>[[Archive.org]][1009]</sup>
+[^218]: Wikipedia, Userspace, <https://en.wikipedia.org/wiki/User_space> <sup>[[Wikiless]][1008]</sup> <sup>[[Archive.org]][1009]</sup>
 
-[^219]: Wikipedia, Firmware <https://en.wikipedia.org/wiki/Firmware> <sup>[[Wikiless]][1010]</sup> <sup>[[Archive.org]][1011]</sup>
+[^219]: Wikipedia, Firmware, <https://en.wikipedia.org/wiki/Firmware> <sup>[[Wikiless]][1010]</sup> <sup>[[Archive.org]][1011]</sup>
 
-[^220]: Wikipedia, BIOS <https://en.wikipedia.org/wiki/BIOS> <sup>[[Wikiless]][1012]</sup> <sup>[[Archive.org]][1013]</sup>
+[^220]: Wikipedia, BIOS, <https://en.wikipedia.org/wiki/BIOS> <sup>[[Wikiless]][1012]</sup> <sup>[[Archive.org]][1013]</sup>
 
-[^221]: Wikipedia, UEFI <https://en.wikipedia.org/wiki/Unified_Extensible_Firmware_Interface> <sup>[[Wikiless]][1014]</sup> <sup>[[Archive.org]][1015]</sup>
+[^221]: Wikipedia, UEFI, <https://en.wikipedia.org/wiki/Unified_Extensible_Firmware_Interface> <sup>[[Wikiless]][1014]</sup> <sup>[[Archive.org]][1015]</sup>
 
-[^222]: Bellingcat, Joseph Mifsud: Rush for the EXIF <https://www.bellingcat.com/news/americas/2018/10/26/joseph-mifsud-rush-exif/> <sup>[[Archive.org]][1016]</sup>
+[^222]: Bellingcat, Joseph Mifsud: Rush for the EXIF, <https://www.bellingcat.com/news/americas/2018/10/26/joseph-mifsud-rush-exif/> <sup>[[Archive.org]][1016]</sup>
 
-[^223]: Zoom Support, Adding a watermark <https://support.zoom.us/hc/en-us/articles/209605273-Adding-a-Watermark> <sup>[[Archive.org]][1017]</sup>
+[^223]: Zoom Support, Adding a watermark, <https://support.zoom.us/hc/en-us/articles/209605273-Adding-a-Watermark> <sup>[[Archive.org]][1017]</sup>
 
-[^224]: Zoom Support, Audio Watermark <https://support.zoom.us/hc/en-us/articles/360021839031-Audio-Watermark> <sup>[[Archive.org]][1018]</sup>
+[^224]: Zoom Support, Audio Watermark, <https://support.zoom.us/hc/en-us/articles/360021839031-Audio-Watermark> <sup>[[Archive.org]][1018]</sup>
 
-[^225]: CreativeCloud Extension, IMATAG <https://exchange.adobe.com/creativecloud.details.101789.imatag-invisible-watermark-and-image-monitoring.html> <sup>[[Archive.org]][1019]</sup>
+[^225]: CreativeCloud Extension, IMATAG, <https://exchange.adobe.com/creativecloud.details.101789.imatag-invisible-watermark-and-image-monitoring.html> <sup>[[Archive.org]][1019]</sup>
 
 [^226]: NexGuard, <https://dtv.nagra.com/nexguard-forensic-watermarking> <sup>[[Archive.org]][1020]</sup>
 
@@ -12525,75 +12525,75 @@ You can find some introduction on these on these projects:
 
 [^229]: Imatag, <https://www.imatag.com/> <sup>[[Archive.org]][1023]</sup>
 
-[^230]: Wikipedia, Steganography <https://en.wikipedia.org/wiki/Steganography> <sup>[[Wikiless]][1024]</sup> <sup>[[Archive.org]][1025]</sup>
+[^230]: Wikipedia, Steganography, <https://en.wikipedia.org/wiki/Steganography> <sup>[[Wikiless]][1024]</sup> <sup>[[Archive.org]][1025]</sup>
 
-[^231]: IEEExplore, A JPEG compression resistant steganography scheme for raster graphics images <https://ieeexplore.ieee.org/document/4428921> <sup>[[Archive.org]][1026]</sup>
+[^231]: IEEExplore, A JPEG compression resistant steganography scheme for raster graphics images, <https://ieeexplore.ieee.org/document/4428921> <sup>[[Archive.org]][1026]</sup>
 
-[^232]: ScienceDirect, Robust audio watermarking using perceptual masking <https://www.researchgate.net/publication/256994444_Robust_Audio_Watermarking_Using_Perceptual_Masking> <sup>[[Archive.org]][1027]</sup>
+[^232]: ScienceDirect, Robust audio watermarking using perceptual masking, <https://www.researchgate.net/publication/256994444_Robust_Audio_Watermarking_Using_Perceptual_Masking> <sup>[[Archive.org]][1027]</sup>
 
-[^233]: IEEExplore, Spread-spectrum watermarking of audio signals <https://www.researchgate.net/publication/3318571_Spread-Spectrum_Watermarking_of_Audio> <sup>[[Archive.org]][1028]</sup>
+[^233]: IEEExplore, Spread-spectrum watermarking of audio signals, <https://www.researchgate.net/publication/3318571_Spread-Spectrum_Watermarking_of_Audio> <sup>[[Archive.org]][1028]</sup>
 
-[^234]: Google Scholar, source camera identification <https://scholar.google.com/scholar?q=source+camera+identification> <sup>[[Archive.org]][1029]</sup>
+[^234]: Google Scholar, source camera identification, <https://scholar.google.com/scholar?q=source+camera+identification> <sup>[[Archive.org]][1029]</sup>
 
-[^235]: Wikipedia, Printing Steganography <https://en.wikipedia.org/wiki/Machine_Identification_Code> <sup>[[Wikiless]][1030]</sup> <sup>[[Archive.org]][1031]</sup>
+[^235]: Wikipedia, Printing Steganography, <https://en.wikipedia.org/wiki/Machine_Identification_Code> <sup>[[Wikiless]][1030]</sup> <sup>[[Archive.org]][1031]</sup>
 
 [^236]: MIT, SeeingYellow, <https://web.archive.org/web/20220224174025/http://seeingyellow.com/> <sup>[[Archive.org]][1032]</sup>
 
-[^237]: arXiv, An Analysis of Anonymity in the Bitcoin System <https://arxiv.org/pdf/1107.4524.pdf> <sup>[[Archive.org]][1033]</sup>
+[^237]: arXiv, An Analysis of Anonymity in the Bitcoin System, <https://arxiv.org/pdf/1107.4524.pdf> <sup>[[Archive.org]][1033]</sup>
 
 [^238]: Bellingcat, How To Track Illegal Funding Campaigns Via Cryptocurrency, <https://www.bellingcat.com/resources/how-tos/2019/03/26/how-to-track-illegal-funding-campaigns-via-cryptocurrency/> <sup>[[Archive.org]][1034]</sup>
 
-[^239]: CoinDesk, Leaked Slides Show How Chainalysis Flags Crypto Suspects for Cops <https://www.coindesk.com/business/2021/09/21/leaked-slides-show-how-chainalysis-flags-crypto-suspects-for-cops/> <sup>[[Archive.org]][1035]</sup>
+[^239]: CoinDesk, Leaked Slides Show How Chainalysis Flags Crypto Suspects for Cops, <https://www.coindesk.com/business/2021/09/21/leaked-slides-show-how-chainalysis-flags-crypto-suspects-for-cops/> <sup>[[Archive.org]][1035]</sup>
 
-[^240]: Wikipedia, KYC <https://en.wikipedia.org/wiki/Know_your_customer> <sup>[[Wikiless]][1036]</sup> <sup>[[Archive.org]][1037]</sup>
+[^240]: Wikipedia, KYC, <https://en.wikipedia.org/wiki/Know_your_customer> <sup>[[Wikiless]][1036]</sup> <sup>[[Archive.org]][1037]</sup>
 
-[^241]: arXiv.org, Probing the Mystery of Cryptocurrency Theft: An Investigation into Methods for Taint Analysis <https://arxiv.org/pdf/1906.05754.pdf> <sup>[[Archive.org]][1038]</sup>
+[^241]: arXiv.org, Probing the Mystery of Cryptocurrency Theft: An Investigation into Methods for Taint Analysis, <https://arxiv.org/pdf/1906.05754.pdf> <sup>[[Archive.org]][1038]</sup>
 
-[^242]: YouTube, Breaking Monero <https://www.youtube.com/watch?v=WOyC6OB6ezA&list=PLsSYUeVwrHBnAUre2G_LYDsdo-tD0ov-y> <sup>[[Invidious]][1039]</sup>
+[^242]: YouTube, Breaking Monero, <https://www.youtube.com/watch?v=WOyC6OB6ezA&list=PLsSYUeVwrHBnAUre2G_LYDsdo-tD0ov-y> <sup>[[Invidious]][1039]</sup>
 
 [^243]: Monero, Monero vs Princeton Researchers, <https://monero.org/monero-vs-princeton-researchers/> <sup>[[Archive.org]][1040]</sup>
 
-[^244]: Wikipedia, Cryptocurrency Tumbler <https://en.wikipedia.org/wiki/Cryptocurrency_tumbler> <sup>[[Wikiless]][1041]</sup> <sup>[[Archive.org]][1042]</sup>
+[^244]: Wikipedia, Cryptocurrency Tumbler, <https://en.wikipedia.org/wiki/Cryptocurrency_tumbler> <sup>[[Wikiless]][1041]</sup> <sup>[[Archive.org]][1042]</sup>
 
-[^245]: Wikipedia, Security Through Obscurity <https://en.wikipedia.org/wiki/Security_through_obscurity> <sup>[[Wikiless]][1043]</sup> <sup>[[Archive.org]][1044]</sup>
+[^245]: Wikipedia, Security Through Obscurity, <https://en.wikipedia.org/wiki/Security_through_obscurity> <sup>[[Wikiless]][1043]</sup> <sup>[[Archive.org]][1044]</sup>
 
-[^246]: ArXiv, Tracking Mixed Bitcoins <https://arxiv.org/pdf/2009.14007.pdf> <sup>[[Archive.org]][1045]</sup>
+[^246]: ArXiv, Tracking Mixed Bitcoins, <https://arxiv.org/pdf/2009.14007.pdf> <sup>[[Archive.org]][1045]</sup>
 
-[^247]: SSRN, The Cryptocurrency Tumblers: Risks, Legality and Oversight <https://www.researchgate.net/publication/321786355_The_Cryptocurrency_Tumblers_Risks_Legality_and_Oversight> <sup>[[Archive.org]][1046]</sup>
+[^247]: SSRN, The Cryptocurrency Tumblers: Risks, Legality and Oversight, <https://www.researchgate.net/publication/321786355_The_Cryptocurrency_Tumblers_Risks_Legality_and_Oversight> <sup>[[Archive.org]][1046]</sup>
 
-[^248]: Magnet Forensics, Magnet AXIOM <https://www.magnetforensics.com/products/magnet-axiom/cloud/> <sup>[[Archive.org]][1047]</sup>
+[^248]: Magnet Forensics, Magnet AXIOM, <https://www.magnetforensics.com/products/magnet-axiom/cloud/> <sup>[[Archive.org]][1047]</sup>
 
-[^249]: Cellebrite, Unlock cloud-based evidence to solve the case sooner <https://www.cellebrite.com/en/ufed-cloud/> <sup>[[Archive.org]][1048]</sup>
+[^249]: Cellebrite, Unlock cloud-based evidence to solve the case sooner, <https://www.cellebrite.com/en/ufed-cloud/> <sup>[[Archive.org]][1048]</sup>
 
 [^250]: Property of the People, Lawful Access to Secure Messaging Apps Data, <https://propertyofthepeople.org/document-detail/?doc-id=21114562> <sup>[[Archive.org]][1049]</sup>
 
-[^251]: Chromium Documentation, Technical analysis of client identification mechanisms <https://sites.google.com/a/chromium.org/dev/Home/chromium-security/client-identification-mechanisms#TOC-Machine-specific-characteristics> <sup>[[Archive.org]][1050]</sup>
+[^251]: Chromium Documentation, Technical analysis of client identification mechanisms, <https://sites.google.com/a/chromium.org/dev/Home/chromium-security/client-identification-mechanisms#TOC-Machine-specific-characteristics> <sup>[[Archive.org]][1050]</sup>
 
-[^252]: Mozilla Wiki, Fingerprinting <https://wiki.mozilla.org/Fingerprinting> <sup>[[Archive.org]][1051]</sup>
+[^252]: Mozilla Wiki, Fingerprinting, <https://wiki.mozilla.org/Fingerprinting> <sup>[[Archive.org]][1051]</sup>
 
 [^253]: Grayshift, <https://www.grayshift.com/> <sup>[[Archive.org]][1052]</sup>
 
-[^254]: Securephones.io, Data Security on Mobile Devices: Current State of the Art, Open Problems, and Proposed Solutions <https://securephones.io/main.pdf> <sup>[[Archive.org]][1053]</sup>
+[^254]: Securephones.io, Data Security on Mobile Devices: Current State of the Art, Open Problems, and Proposed Solutions, <https://securephones.io/main.pdf> <sup>[[Archive.org]][1053]</sup>
 
-[^255]: Loup-Vaillant.fr, Rolling Your Own Crypto <https://loup-vaillant.fr/articles/rolling-your-own-crypto> <sup>[[Archive.org]][1054]</sup>
+[^255]: Loup-Vaillant.fr, Rolling Your Own Crypto, <https://loup-vaillant.fr/articles/rolling-your-own-crypto> <sup>[[Archive.org]][1054]</sup>
 
-[^256]: Dhole Moments, Crackpot Cryptography and Security Theater <https://soatok.blog/2021/02/09/crackpot-cryptography-and-security-theater/> <sup>[[Archive.org]][1055]</sup>
+[^256]: Dhole Moments, Crackpot Cryptography and Security Theater, <https://soatok.blog/2021/02/09/crackpot-cryptography-and-security-theater/> <sup>[[Archive.org]][1055]</sup>
 
-[^257]: Vice.com, Why You Don't Roll Your Own Crypto <https://www.vice.com/en/article/wnx8nq/why-you-dont-roll-your-own-crypto> <sup>[[Archive.org]][1056]</sup>
+[^257]: Vice.com, Why You Don't Roll Your Own Crypto, <https://www.vice.com/en/article/wnx8nq/why-you-dont-roll-your-own-crypto> <sup>[[Archive.org]][1056]</sup>
 
-[^258]: arXiv, MIT, You Really Shouldn't Roll Your Own Crypto: An Empirical Study of Vulnerabilities in Cryptographic Libraries <https://arxiv.org/pdf/2107.04940.pdf> <sup>[[Archive.org]][1057]</sup>
+[^258]: arXiv, MIT, You Really Shouldn't Roll Your Own Crypto: An Empirical Study of Vulnerabilities in Cryptographic Libraries, <https://arxiv.org/pdf/2107.04940.pdf> <sup>[[Archive.org]][1057]</sup>
 
-[^259]: YouTube, Great Crypto Failures <https://www.youtube.com/watch?v=loy84K3AJ5Q> <sup>[[Invidious]][1058]</sup>
+[^259]: YouTube, Great Crypto Failures, <https://www.youtube.com/watch?v=loy84K3AJ5Q> <sup>[[Invidious]][1058]</sup>
 
-[^260]: Cryptography Dispatches, The Most Backdoor-Looking Bug I've Ever Seen <https://buttondown.email/cryptography-dispatches/archive/cryptography-dispatches-the-most-backdoor-looking/> <sup>[[Archive.org]][169]</sup>
+[^260]: Cryptography Dispatches, The Most Backdoor-Looking Bug I've Ever Seen, <https://buttondown.email/cryptography-dispatches/archive/cryptography-dispatches-the-most-backdoor-looking/> <sup>[[Archive.org]][169]</sup>
 
-[^261]: Citizenlab.ca, Move Fast and Roll Your Own Crypto <https://citizenlab.ca/2020/04/move-fast-roll-your-own-crypto-a-quick-look-at-the-confidentiality-of-zoom-meetings/> <sup>[[Archive.org]][1059]</sup>
+[^261]: Citizenlab.ca, Move Fast and Roll Your Own Crypto, <https://citizenlab.ca/2020/04/move-fast-roll-your-own-crypto-a-quick-look-at-the-confidentiality-of-zoom-meetings/> <sup>[[Archive.org]][1059]</sup>
 
-[^262]: Jack Poon, The myth of military grade encryption <https://medium.com/@atcipher/the-myth-of-military-grade-encryption-292313ae6369> <sup>[[Scribe.rip]][1060]</sup> <sup>[[Archive.org]][1061]</sup>
+[^262]: Jack Poon, The myth of military grade encryption, <https://medium.com/@atcipher/the-myth-of-military-grade-encryption-292313ae6369> <sup>[[Scribe.rip]][1060]</sup> <sup>[[Archive.org]][1061]</sup>
 
-[^263]: Congruent Labs, Stop calling it "Military-Grade Encryption" <https://blog.congruentlabs.co/military-grade-encryption/> <sup>[[Archive.org]][1062]</sup>
+[^263]: Congruent Labs, Stop calling it "Military-Grade Encryption", <https://blog.congruentlabs.co/military-grade-encryption/> <sup>[[Archive.org]][1062]</sup>
 
-[^264]: IronCoreLabs Blog, "Military Grade Encryption" <https://blog.ironcorelabs.com/military-grade-encryption-69aae0145588> <sup>[[Archive.org]][1063]</sup>
+[^264]: IronCoreLabs Blog, "Military Grade Encryption", <https://blog.ironcorelabs.com/military-grade-encryption-69aae0145588> <sup>[[Archive.org]][1063]</sup>
 
 [^265]: Wikipedia, BLAKE2, <https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2> <sup>[[Wikiless]][1064]</sup> <sup>[[Archive.org]][1065]</sup>
 
@@ -12605,439 +12605,439 @@ You can find some introduction on these on these projects:
 
 [^269]: Wikipedia, TwoFish, <https://en.wikipedia.org/wiki/Twofish> <sup>[[Wikiless]][1072]</sup> <sup>[[Archive.org]][1073]</sup>
 
-[^270]: Lacatora, The PGP Problem <https://latacora.singles/2019/07/16/the-pgp-problem.html> <sup>[[Archive.org]][1074]</sup>
+[^270]: Lacatora, The PGP Problem, <https://latacora.singles/2019/07/16/the-pgp-problem.html> <sup>[[Archive.org]][1074]</sup>
 
 [^271]: Wikipedia, Shor's Algorithm, <https://en.wikipedia.org/wiki/Shor%27s_algorithm> <sup>[[Wikiless]][1075]</sup> <sup>[[Archive.org]][1076]</sup>
 
 [^272]: Wikipedia, Gag Order, <https://en.wikipedia.org/wiki/Gag_order> <sup>[[Wikiless]][1077]</sup> <sup>[[Archive.org]][1078]</sup>
 
-[^273]: Wikipedia, National Security Letter <https://en.wikipedia.org/wiki/National_security_letter> <sup>[[Wikiless]][1079]</sup> <sup>[[Archive.org]][1080]</sup>
+[^273]: Wikipedia, National Security Letter, <https://en.wikipedia.org/wiki/National_security_letter> <sup>[[Wikiless]][1079]</sup> <sup>[[Archive.org]][1080]</sup>
 
-[^274]: TechCrunch, ProtonMail logged IP address of French activist after order by Swiss authorities <https://techcrunch.com/2021/09/06/protonmail-logged-ip-address-of-french-activist-after-order-by-swiss-authorities/> <sup>[[Archive.org]][1081]</sup>
+[^274]: TechCrunch, ProtonMail logged IP address of French activist after order by Swiss authorities, <https://techcrunch.com/2021/09/06/protonmail-logged-ip-address-of-french-activist-after-order-by-swiss-authorities/> <sup>[[Archive.org]][1081]</sup>
 
-[^275]: ArsTechnica, VPN servers seized by Ukrainian authorities weren't encrypted <https://arstechnica.com/gadgets/2021/07/vpn-servers-seized-by-ukrainian-authorities-werent-encrypted/> <sup>[[Archive.org]][1082]</sup>
+[^275]: ArsTechnica, VPN servers seized by Ukrainian authorities weren't encrypted, <https://arstechnica.com/gadgets/2021/07/vpn-servers-seized-by-ukrainian-authorities-werent-encrypted/> <sup>[[Archive.org]][1082]</sup>
 
-[^276]: BleepingComputer, DoubleVPN servers, logs, and account info seized by law enforcement <https://www.bleepingcomputer.com/news/security/doublevpn-servers-logs-and-account-info-seized-by-law-enforcement/> <sup>[[Archive.org]][1083]</sup>
+[^276]: BleepingComputer, DoubleVPN servers, logs, and account info seized by law enforcement, <https://www.bleepingcomputer.com/news/security/doublevpn-servers-logs-and-account-info-seized-by-law-enforcement/> <sup>[[Archive.org]][1083]</sup>
 
-[^277]: CyberScoop, Court rules encrypted email provider Tutanota must monitor messages in blackmail case <https://www.cyberscoop.com/court-rules-encrypted-email-tutanota-monitor-messages/> <sup>[[Archive.org]][1084]</sup>
+[^277]: CyberScoop, Court rules encrypted email provider Tutanota must monitor messages in blackmail case, <https://www.cyberscoop.com/court-rules-encrypted-email-tutanota-monitor-messages/> <sup>[[Archive.org]][1084]</sup>
 
 [^278]: Heise Online (German), <https://www.heise.de/news/Gericht-zwingt-Mailprovider-Tutanota-zu-Ueberwachungsfunktion-4972460.html> <sup>[[Archive.org]][1085]</sup>
 
-[^279]: PCMag, Did PureVPN Cross a Line When It Disclosed User Information? <https://www.pcmag.com/opinions/did-purevpn-cross-a-line-when-it-disclosed-user-information> <sup>[[Archive.org]][1086]</sup>
+[^279]: PCMag, Did PureVPN Cross a Line When It Disclosed User Information?, <https://www.pcmag.com/opinions/did-purevpn-cross-a-line-when-it-disclosed-user-information> <sup>[[Archive.org]][1086]</sup>
 
-[^280]: Internet Archive, Wipeyourdata, "No logs" EarthVPN user arrested after police finds logs <https://archive.is/XNuVw#selection-230.0-230.1> <sup>[[Archive.org]][1087]</sup>
+[^280]: Internet Archive, Wipeyourdata, "No logs" EarthVPN user arrested after police finds logs, <https://archive.is/XNuVw#selection-230.0-230.1> <sup>[[Archive.org]][1087]</sup>
 
 [^281]: Wikipedia, Lavabit Suspension and Gag order, <https://en.wikipedia.org/wiki/Lavabit#Suspension_and_gag_order> <sup>[[Wikiless]][1088]</sup> <sup>[[Archive.org]][1089]</sup>
 
-[^282]: Internet Archive, Invisibler, What Everybody Ought to Know About HideMyAss <https://archive.is/ag9w4#selection-136.0-136.1>
+[^282]: Internet Archive, Invisibler, What Everybody Ought to Know About HideMyAss, <https://archive.is/ag9w4#selection-136.0-136.1>
 
-[^283]: Wikipedia, Warrant Canary <https://en.wikipedia.org/wiki/Warrant_canary> <sup>[[Wikiless]][1090]</sup> <sup>[[Archive.org]][1091]</sup>
+[^283]: Wikipedia, Warrant Canary, <https://en.wikipedia.org/wiki/Warrant_canary> <sup>[[Wikiless]][1090]</sup> <sup>[[Archive.org]][1091]</sup>
 
-[^284]: Washington Post, The intelligence coup of the century <https://www.washingtonpost.com/graphics/2020/world/national-security/cia-crypto-encryption-machines-espionage/> <sup>[[Archive.org]][1092]</sup>
+[^284]: Washington Post, The intelligence coup of the century, <https://www.washingtonpost.com/graphics/2020/world/national-security/cia-crypto-encryption-machines-espionage/> <sup>[[Archive.org]][1092]</sup>
 
-[^285]: Swissinfo.ch, Second Swiss firm allegedly sold encrypted spying devices <https://www.swissinfo.ch/eng/second-swiss-firm-allegedly-sold-encrypted-spying-devices/46186432> <sup>[[Archive.org]][1093]</sup>
+[^285]: Swissinfo.ch, Second Swiss firm allegedly sold encrypted spying devices, <https://www.swissinfo.ch/eng/second-swiss-firm-allegedly-sold-encrypted-spying-devices/46186432> <sup>[[Archive.org]][1093]</sup>
 
-[^286]: Wikipedia, Das Leben der Anderen <https://en.wikipedia.org/wiki/The_Lives_of_Others> <sup>[[Wikiless]][1094]</sup> <sup>[[Archive.org]][1095]</sup>
+[^286]: Wikipedia, Das Leben der Anderen, <https://en.wikipedia.org/wiki/The_Lives_of_Others> <sup>[[Wikiless]][1094]</sup> <sup>[[Archive.org]][1095]</sup>
 
-[^287]: Wired, Mind the Gap: This Researcher Steals Data With Noise, Light, and Magnets <https://www.wired.com/story/air-gap-researcher-mordechai-guri/> <sup>[[Archive.org]][1096]</sup>
+[^287]: Wired, Mind the Gap: This Researcher Steals Data With Noise, Light, and Magnets, <https://www.wired.com/story/air-gap-researcher-mordechai-guri/> <sup>[[Archive.org]][1096]</sup>
 
-[^288]: Scientific American, A Blank Wall Can Show How Many People Are in a Room and What They're Doing <https://www.scientificamerican.com/article/a-blank-wall-can-show-how-many-people-are-in-a-room-and-what-theyre-doing/> <sup>[[Archive.org]][1097]</sup>
+[^288]: Scientific American, A Blank Wall Can Show How Many People Are in a Room and What They're Doing, <https://www.scientificamerican.com/article/a-blank-wall-can-show-how-many-people-are-in-a-room-and-what-theyre-doing/> <sup>[[Archive.org]][1097]</sup>
 
-[^289]: Scientific American, A Shiny Snack Bag's Reflections Can Reconstruct the Room around It <https://www.scientificamerican.com/article/a-shiny-snack-bags-reflections-can-reconstruct-the-room-around-it/> <sup>[[Archive.org]][1098]</sup>
+[^289]: Scientific American, A Shiny Snack Bag's Reflections Can Reconstruct the Room around It, <https://www.scientificamerican.com/article/a-shiny-snack-bags-reflections-can-reconstruct-the-room-around-it/> <sup>[[Archive.org]][1098]</sup>
 
-[^290]: Scientific American, Footstep Sensors Identify People by Gait <https://www.scientificamerican.com/article/footstep-sensors-identify-people-by-gait/> <sup>[[Archive.org]][1099]</sup>
+[^290]: Scientific American, Footstep Sensors Identify People by Gait, <https://www.scientificamerican.com/article/footstep-sensors-identify-people-by-gait/> <sup>[[Archive.org]][1099]</sup>
 
-[^291]: Ben Nassi, Lamphone <https://www.nassiben.com/lamphone> <sup>[[Archive.org]][1100]</sup>
+[^291]: Ben Nassi, Lamphone, <https://www.nassiben.com/lamphone> <sup>[[Archive.org]][1100]</sup>
 
-[^292]: The Guardian, Laser spying: is it really practical? <https://www.theguardian.com/world/2013/aug/22/gchq-warned-laser-spying-guardian-offices> <sup>[[Archive.org]][1101]</sup>
+[^292]: The Guardian, Laser spying: is it really practical?, <https://www.theguardian.com/world/2013/aug/22/gchq-warned-laser-spying-guardian-offices> <sup>[[Archive.org]][1101]</sup>
 
-[^293]: ArsTechnica, Photos of an NSA "upgrade" factory show Cisco router getting implant <https://arstechnica.com/tech-policy/2014/05/photos-of-an-nsa-upgrade-factory-show-cisco-router-getting-implant/> <sup>[[Archive.org]][1102]</sup>
+[^293]: ArsTechnica, Photos of an NSA "upgrade" factory show Cisco router getting implant, <https://arstechnica.com/tech-policy/2014/05/photos-of-an-nsa-upgrade-factory-show-cisco-router-getting-implant/> <sup>[[Archive.org]][1102]</sup>
 
-[^294]: Wikipedia, Rubber-hose Cryptanalysis <https://en.wikipedia.org/wiki/Rubber-hose_cryptanalysis> <sup>[[Archive.org]][1364]</sup>
+[^294]: Wikipedia, Rubber-hose Cryptanalysis, <https://en.wikipedia.org/wiki/Rubber-hose_cryptanalysis> <sup>[[Archive.org]][1364]</sup>
 
-[^295]: Defuse.ca, TrueCrypt's Plausible Deniability is Theoretically Useless <https://defuse.ca/truecrypt-plausible-deniability-useless-by-game-theory.htm> <sup>[[Archive.org]][248]</sup>
+[^295]: Defuse.ca, TrueCrypt's Plausible Deniability is Theoretically Useless, <https://defuse.ca/truecrypt-plausible-deniability-useless-by-game-theory.htm> <sup>[[Archive.org]][248]</sup>
 
 [^296]: Wikipedia, OONI, <https://en.wikipedia.org/wiki/OONI> <sup>[[Wikiless]][1103]</sup> <sup>[[Archive.org]][1104]</sup>
 
-[^297]: Privacy International, Timeline of SIM Card Registration Laws <https://privacyinternational.org/long-read/3018/timeline-sim-card-registration-laws> <sup>[[Archive.org]][1105]</sup>
+[^297]: Privacy International, Timeline of SIM Card Registration Laws, <https://privacyinternational.org/long-read/3018/timeline-sim-card-registration-laws> <sup>[[Archive.org]][1105]</sup>
 
-[^298]: NYTimes, Lost Passwords Lock Millionaires Out of Their Bitcoin Fortunes <https://www.nytimes.com/2021/01/12/technology/bitcoin-passwords-wallets-fortunes.html> <sup>[[Archive.org]][1106]</sup>
+[^298]: NYTimes, Lost Passwords Lock Millionaires Out of Their Bitcoin Fortunes, <https://www.nytimes.com/2021/01/12/technology/bitcoin-passwords-wallets-fortunes.html> <sup>[[Archive.org]][1106]</sup>
 
-[^299]: Usenix.org, Shedding too much Light on a Microcontroller's Firmware Protection <https://www.usenix.org/system/files/conference/woot17/woot17-paper-obermaier.pdf> <sup>[[Archive.org]][1107]</sup>
+[^299]: Usenix.org, Shedding too much Light on a Microcontroller's Firmware Protection, <https://www.usenix.org/system/files/conference/woot17/woot17-paper-obermaier.pdf> <sup>[[Archive.org]][1107]</sup>
 
-[^300]: TorProject.org, Can I run Tor Browser on an iOS device? <https://support.torproject.org/tormobile/tormobile-3/> <sup>[[Archive.org]][1108]</sup>
+[^300]: TorProject.org, Can I run Tor Browser on an iOS device?, <https://support.torproject.org/tormobile/tormobile-3/> <sup>[[Archive.org]][1108]</sup>
 
-[^301]: Wikipedia, Tails <https://en.wikipedia.org/wiki/Tails_(operating_system)> <sup>[[Wikiless]][1109]</sup> <sup>[[Archive.org]][1110]</sup>
+[^301]: Wikipedia, Tails, <https://en.wikipedia.org/wiki/Tails_(operating_system)> <sup>[[Wikiless]][1109]</sup> <sup>[[Archive.org]][1110]</sup>
 
-[^302]: Vice.com, Facebook Helped the FBI Hack a Child Predator <https://www.vice.com/en/article/v7gd9b/facebook-helped-fbi-hack-child-predator-buster-hernandez> <sup>[[Archive.org]][674]</sup>
+[^302]: Vice.com, Facebook Helped the FBI Hack a Child Predator, <https://www.vice.com/en/article/v7gd9b/facebook-helped-fbi-hack-child-predator-buster-hernandez> <sup>[[Archive.org]][674]</sup>
 
-[^303]: Veracrypt Documentation, Trim Operations <https://www.veracrypt.fr/en/Trim%20Operation.html> <sup>[[Archive.org]][1111]</sup>
+[^303]: Veracrypt Documentation, Trim Operations, <https://www.veracrypt.fr/en/Trim%20Operation.html> <sup>[[Archive.org]][1111]</sup>
 
-[^304]: YouTube, 36C3 - Uncover, Understand, Own - Regaining Control Over Your AMD CPU <https://www.youtube.com/watch?v=bKH5nGLgi08&t=2834s> <sup>[[Invidious]][77]</sup>
+[^304]: YouTube, 36C3 - Uncover, Understand, Own - Regaining Control Over Your AMD CPU, <https://www.youtube.com/watch?v=bKH5nGLgi08&t=2834s> <sup>[[Invidious]][77]</sup>
 
 [^305]: Qubes OS, Anti-Evil Maid, <https://github.com/QubesOS/qubes-antievilmaid> <sup>[[Archive.org]][269]</sup>
 
 [^306]: QubesOS FAQ, <https://www.qubes-os.org/faq/#is-secure-boot-supported> <sup>[[Archive.org]][369]</sup>
 
-[^307]: Wikipedia, Secure Boot <https://en.wikipedia.org/wiki/Unified_Extensible_Firmware_Interface#Secure_boot> <sup>[[Wikiless]][1014]</sup> <sup>[[Archive.org]][1015]</sup>
+[^307]: Wikipedia, Secure Boot, <https://en.wikipedia.org/wiki/Unified_Extensible_Firmware_Interface#Secure_boot> <sup>[[Wikiless]][1014]</sup> <sup>[[Archive.org]][1015]</sup>
 
-[^308]: Wikipedia, Booting <https://en.wikipedia.org/wiki/Booting> <sup>[[Wikiless]][1112]</sup> <sup>[[Archive.org]][1113]</sup>
+[^308]: Wikipedia, Booting, <https://en.wikipedia.org/wiki/Booting> <sup>[[Wikiless]][1112]</sup> <sup>[[Archive.org]][1113]</sup>
 
-[^309]: Wired, Don't Want Your Laptop Tampered With? Just Add Glitter Nail Polish <https://www.wired.com/2013/12/better-data-security-nail-polish/> <sup>[[Archive.org]][1114]</sup>
+[^309]: Wired, Don't Want Your Laptop Tampered With? Just Add Glitter Nail Polish, <https://www.wired.com/2013/12/better-data-security-nail-polish/> <sup>[[Archive.org]][1114]</sup>
 
-[^310]: Wikipedia, Virtual Machine <https://en.wikipedia.org/wiki/Virtual_machine> <sup>[[Wikiless]][1115]</sup> <sup>[[Archive.org]][1116]</sup>
+[^310]: Wikipedia, Virtual Machine, <https://en.wikipedia.org/wiki/Virtual_machine> <sup>[[Wikiless]][1115]</sup> <sup>[[Archive.org]][1116]</sup>
 
-[^311]: Wikipedia, Plausible Deniability <https://en.wikipedia.org/wiki/Plausible_deniability> <sup>[[Wikiless]][1117]</sup> <sup>[[Archive.org]][1118]</sup>
+[^311]: Wikipedia, Plausible Deniability, <https://en.wikipedia.org/wiki/Plausible_deniability> <sup>[[Wikiless]][1117]</sup> <sup>[[Archive.org]][1118]</sup>
 
-[^312]: Wikipedia, Deniable Encryption <https://en.wikipedia.org/wiki/Deniable_encryption> <sup>[[Wikiless]][1119]</sup> <sup>[[Archive.org]][1120]</sup>
+[^312]: Wikipedia, Deniable Encryption, <https://en.wikipedia.org/wiki/Deniable_encryption> <sup>[[Wikiless]][1119]</sup> <sup>[[Archive.org]][1120]</sup>
 
-[^313]: PrivacyGuides.org, Don't use Windows 10 - It's a privacy nightmare <https://web.archive.org/web/20220313023015/https://www.privacyguides.org/tools/#operating-systems#win10> <sup>[[Archive.org]][1121]</sup>
+[^313]: PrivacyGuides.org, Don't use Windows 10 - It's a privacy nightmare, <https://web.archive.org/web/20220313023015/https://www.privacyguides.org/tools/#operating-systems#win10> <sup>[[Archive.org]][1121]</sup>
 
-[^314]: Wikipedia, Deniable Encryption <https://en.wikipedia.org/wiki/Deniable_encryption> <sup>[[Wikiless]][1119]</sup> <sup>[[Archive.org]][1120]</sup>
+[^314]: Wikipedia, Deniable Encryption, <https://en.wikipedia.org/wiki/Deniable_encryption> <sup>[[Wikiless]][1119]</sup> <sup>[[Archive.org]][1120]</sup>
 
-[^315]: Wikipedia, Key Disclosure Laws <https://en.wikipedia.org/wiki/Key_disclosure_law> <sup>[[Wikiless]][554]</sup> <sup>[[Archive.org]][555]</sup>
+[^315]: Wikipedia, Key Disclosure Laws, <https://en.wikipedia.org/wiki/Key_disclosure_law> <sup>[[Wikiless]][554]</sup> <sup>[[Archive.org]][555]</sup>
 
-[^316]: GP Digital, World map of encryption laws and policies <https://www.gp-digital.org/world-map-of-encryption/> <sup>[[Archive.org]][556]</sup>
+[^316]: GP Digital, World map of encryption laws and policies, <https://www.gp-digital.org/world-map-of-encryption/> <sup>[[Archive.org]][556]</sup>
 
-[^317]: Wikipedia, Bitlocker <https://en.wikipedia.org/wiki/BitLocker> <sup>[[Wikiless]][1122]</sup> <sup>[[Archive.org]][1123]</sup>
+[^317]: Wikipedia, Bitlocker, <https://en.wikipedia.org/wiki/BitLocker> <sup>[[Wikiless]][1122]</sup> <sup>[[Archive.org]][1123]</sup>
 
-[^318]: Wikipedia, Evil Maid Attack <https://en.wikipedia.org/wiki/Evil_maid_attack> <sup>[[Wikiless]][1124]</sup> <sup>[[Archive.org]][1125]</sup>
+[^318]: Wikipedia, Evil Maid Attack, <https://en.wikipedia.org/wiki/Evil_maid_attack> <sup>[[Wikiless]][1124]</sup> <sup>[[Archive.org]][1125]</sup>
 
-[^319]: Wikipedia, Cold Boot Attack <https://en.wikipedia.org/wiki/Cold_boot_attack> <sup>[[Wikiless]][1126]</sup> <sup>[[Archive.org]][1127]</sup>
+[^319]: Wikipedia, Cold Boot Attack, <https://en.wikipedia.org/wiki/Cold_boot_attack> <sup>[[Wikiless]][1126]</sup> <sup>[[Archive.org]][1127]</sup>
 
 [^320]: CITP 2008 (<https://www.youtube.com/watch?v=JDaicPIgn9U>) <sup>[[Invidious]][1128]</sup>
 
-[^321]: ResearchGate, Defeating Plausible Deniability of VeraCrypt Hidden Operating Systems <https://www.researchgate.net/publication/318155607_Defeating_Plausible_Deniability_of_VeraCrypt_Hidden_Operating_Systems> <sup>[[Archive.org]][1129]</sup>
+[^321]: ResearchGate, Defeating Plausible Deniability of VeraCrypt Hidden Operating Systems, <https://www.researchgate.net/publication/318155607_Defeating_Plausible_Deniability_of_VeraCrypt_Hidden_Operating_Systems> <sup>[[Archive.org]][1129]</sup>
 
-[^322]: SANS.org, Mission Implausible: Defeating Plausible Deniability with Digital Forensics <https://www.sans.org/reading-room/whitepapers/forensics/mission-implausible-defeating-plausible-deniability-digital-forensics-39500> <sup>[[Archive.org]][1130]</sup>
+[^322]: SANS.org, Mission Implausible: Defeating Plausible Deniability with Digital Forensics, <https://www.sans.org/reading-room/whitepapers/forensics/mission-implausible-defeating-plausible-deniability-digital-forensics-39500> <sup>[[Archive.org]][1130]</sup>
 
-[^323]: SourceForge, Veracrypt Forum <https://sourceforge.net/p/veracrypt/discussion/technical/thread/53f33faf/> <sup>[[Archive.org]][1131]</sup>
+[^323]: SourceForge, Veracrypt Forum, <https://sourceforge.net/p/veracrypt/discussion/technical/thread/53f33faf/> <sup>[[Archive.org]][1131]</sup>
 
-[^324]: Microsoft, BitLocker Countermeasures <https://docs.microsoft.com/en-us/windows/security/information-protection/bitlocker/bitlocker-countermeasures> <sup>[[Archive.org]][1132]</sup>
+[^324]: Microsoft, BitLocker Countermeasures, <https://docs.microsoft.com/en-us/windows/security/information-protection/bitlocker/bitlocker-countermeasures> <sup>[[Archive.org]][1132]</sup>
 
-[^325]: SANS, Windows ShellBag Forensics in-depth <https://www.sans.org/reading-room/whitepapers/forensics/windows-shellbag-forensics-in-depth-34545> <sup>[[Archive.org]][1133]</sup>
+[^325]: SANS, Windows ShellBag Forensics in-depth, <https://www.sans.org/reading-room/whitepapers/forensics/windows-shellbag-forensics-in-depth-34545> <sup>[[Archive.org]][1133]</sup>
 
-[^326]: University of York, Forensic data recovery from the Windows Search Database <https://eprints.whiterose.ac.uk/75046/1/Forensic_Data_Recovery_From_The_Windows_Search_Database_preprint_DIIN328.pdf> <sup>[[Archive.org]][1134]</sup>
+[^326]: University of York, Forensic data recovery from the Windows Search Database, <https://eprints.whiterose.ac.uk/75046/1/Forensic_Data_Recovery_From_The_Windows_Search_Database_preprint_DIIN328.pdf> <sup>[[Archive.org]][1134]</sup>
 
-[^327]: A forensic insight into Windows 10 Jump Lists <https://web.archive.org/web/https://cyberforensicator.com/wp-content/uploads/2017/01/1-s2.0-S1742287616300202-main.2-14.pdf> <sup>[[Archive.org]][1135]</sup>
+[^327]: A forensic insight into Windows 10 Jump Lists, <https://web.archive.org/web/https://cyberforensicator.com/wp-content/uploads/2017/01/1-s2.0-S1742287616300202-main.2-14.pdf> <sup>[[Archive.org]][1135]</sup>
 
-[^328]: Wikipedia, Gatekeeper <https://en.wikipedia.org/wiki/Gatekeeper_(macOS)> <sup>[[Wikiless]][1136]</sup> <sup>[[Archive.org]][1137]</sup>
+[^328]: Wikipedia, Gatekeeper, <https://en.wikipedia.org/wiki/Gatekeeper_(macOS)> <sup>[[Wikiless]][1136]</sup> <sup>[[Archive.org]][1137]</sup>
 
-[^329]: Alpine Linux Wiki, Setting up a laptop <https://wiki.alpinelinux.org/wiki/Setting_up_a_laptop> <sup>[[Archive.org]][1138]</sup>
+[^329]: Alpine Linux Wiki, Setting up a laptop, <https://wiki.alpinelinux.org/wiki/Setting_up_a_laptop> <sup>[[Archive.org]][1138]</sup>
 
-[^330]: Wikipedia Veracrypt <https://en.wikipedia.org/wiki/VeraCrypt> <sup>[[Wikiless]][1139]</sup> <sup>[[Archive.org]][1140]</sup>
+[^330]: Wikipedia Veracrypt, <https://en.wikipedia.org/wiki/VeraCrypt> <sup>[[Wikiless]][1139]</sup> <sup>[[Archive.org]][1140]</sup>
 
-[^331]: OSTIF Veracrypt Audit, 2016 <https://web.archive.org/web/https://ostif.org/the-veracrypt-audit-results/>
+[^331]: OSTIF Veracrypt Audit, 2016, <https://web.archive.org/web/https://ostif.org/the-veracrypt-audit-results/>
 
-[^332]: Veracrypt Documentation, Unencrypted Data in RAM <https://www.veracrypt.fr/en/Unencrypted%20Data%20in%20RAM.html> <sup>[[Archive.org]][1141]</sup>
+[^332]: Veracrypt Documentation, Unencrypted Data in RAM, <https://www.veracrypt.fr/en/Unencrypted%20Data%20in%20RAM.html> <sup>[[Archive.org]][1141]</sup>
 
-[^333]: Veracrypt Documentation, Data Leaks <https://www.veracrypt.fr/code/VeraCrypt/plain/doc/html/Data%20Leaks.html> <sup>[[Archive.org]][1142]</sup>
+[^333]: Veracrypt Documentation, Data Leaks, <https://www.veracrypt.fr/code/VeraCrypt/plain/doc/html/Data%20Leaks.html> <sup>[[Archive.org]][1142]</sup>
 
-[^334]: Dolos Group, From Stolen Laptop to Inside the Company Network <https://dolosgroup.io/blog/2021/7/9/from-stolen-laptop-to-inside-the-company-network> <sup>[[Archive.org]][1143]</sup>
+[^334]: Dolos Group, From Stolen Laptop to Inside the Company Network, <https://dolosgroup.io/blog/2021/7/9/from-stolen-laptop-to-inside-the-company-network> <sup>[[Archive.org]][1143]</sup>
 
-[^335]: Trammell Hudson's Projects, Understanding TPM Sniffing Attacks <https://trmm.net/tpm-sniffing/> <sup>[[Archive.org]][1144]</sup>
+[^335]: Trammell Hudson's Projects, Understanding TPM Sniffing Attacks, <https://trmm.net/tpm-sniffing/> <sup>[[Archive.org]][1144]</sup>
 
-[^336]: Jon Aubrey, attacking laptops that are protected by Microsoft Bitlocker drive encryption <https://twitter.com/SecurityJon/status/1445020885472235524> <sup>[[Nitter]][1145]</sup>
+[^336]: Jon Aubrey, attacking laptops that are protected by Microsoft Bitlocker drive encryption, <https://twitter.com/SecurityJon/status/1445020885472235524> <sup>[[Nitter]][1145]</sup>
 
-[^337]: F-Secure Labs, Sniff, there leaks my BitLocker key <https://labs.f-secure.com/blog/sniff-there-leaks-my-bitlocker-key/> <sup>[[Archive.org]][1146]</sup>
+[^337]: F-Secure Labs, Sniff, there leaks my BitLocker key, <https://labs.f-secure.com/blog/sniff-there-leaks-my-bitlocker-key/> <sup>[[Archive.org]][1146]</sup>
 
-[^338]: Microsoft, BitLocker Countermeasures, Attacker countermeasures <https://docs.microsoft.com/en-us/windows/security/information-protection/bitlocker/bitlocker-countermeasures> <sup>[[Archive.org]][1132]</sup>
+[^338]: Microsoft, BitLocker Countermeasures, Attacker countermeasures, <https://docs.microsoft.com/en-us/windows/security/information-protection/bitlocker/bitlocker-countermeasures> <sup>[[Archive.org]][1132]</sup>
 
-[^339]: Wikipedia, Trim <https://en.wikipedia.org/wiki/Trim_(computing)> <sup>[[Wikiless]][485]</sup> <sup>[[Archive.org]][486]</sup>
+[^339]: Wikipedia, Trim, <https://en.wikipedia.org/wiki/Trim_(computing)> <sup>[[Wikiless]][485]</sup> <sup>[[Archive.org]][486]</sup>
 
-[^340]: Veracrypt Documentation, Trim Operations <https://www.veracrypt.fr/en/Trim%20Operation.html> <sup>[[Archive.org]][1111]</sup>
+[^340]: Veracrypt Documentation, Trim Operations, <https://www.veracrypt.fr/en/Trim%20Operation.html> <sup>[[Archive.org]][1111]</sup>
 
-[^341]: Veracrypt Documentation, Rescue Disk <https://www.veracrypt.fr/en/VeraCrypt%20Rescue%20Disk.html> <sup>[[Archive.org]][1147]</sup>
+[^341]: Veracrypt Documentation, Rescue Disk, <https://www.veracrypt.fr/en/VeraCrypt%20Rescue%20Disk.html> <sup>[[Archive.org]][1147]</sup>
 
-[^342]: St Cloud State University, Forensic Research on Solid State Drives using Trim Analysis <https://repository.stcloudstate.edu/cgi/viewcontent.cgi?article=1141&context=msia_etds> <sup>[[Archive.org]][1148]</sup>
+[^342]: St Cloud State University, Forensic Research on Solid State Drives using Trim Analysis, <https://repository.stcloudstate.edu/cgi/viewcontent.cgi?article=1141&context=msia_etds> <sup>[[Archive.org]][1148]</sup>
 
-[^343]: WindowsCentral, Trim Tutorial <https://www.windowscentral.com/how-ensure-trim-enabled-windows-10-speed-ssd-performance> <sup>[[Archive.org]][1149]</sup>
+[^343]: WindowsCentral, Trim Tutorial, <https://www.windowscentral.com/how-ensure-trim-enabled-windows-10-speed-ssd-performance> <sup>[[Archive.org]][1149]</sup>
 
-[^344]: Veracrypt Documentation, Trim Operation <https://veracrypt.eu/en/docs/trim-operation/> <sup>[[Archive.org]][1150]</sup>
+[^344]: Veracrypt Documentation, Trim Operation, <https://veracrypt.eu/en/docs/trim-operation/> <sup>[[Archive.org]][1150]</sup>
 
-[^345]: Black Hat 2018, Perfectly Deniable Steganographic Disk Encryption <https://i.blackhat.com/eu-18/Thu-Dec-6/eu-18-Schaub-Perfectly-Deniable-Steganographic-Disk-Encryption.pdf> <sup>[[Archive.org]][1151]</sup>
+[^345]: Black Hat 2018, Perfectly Deniable Steganographic Disk Encryption, <https://i.blackhat.com/eu-18/Thu-Dec-6/eu-18-Schaub-Perfectly-Deniable-Steganographic-Disk-Encryption.pdf> <sup>[[Archive.org]][1151]</sup>
 
 [^346]: Milan Broz's Blog, TRIM & dm-crypt ... problems? <http://asalor.blogspot.com/2011/08/trim-dm-crypt-problems.html> <sup>[[Archive.org]][1152]</sup>
 
-[^347]: Veracrypt Documentation, Rescue Disk <https://www.veracrypt.fr/en/VeraCrypt%20Rescue%20Disk.html> <sup>[[Archive.org]][1147]</sup>
+[^347]: Veracrypt Documentation, Rescue Disk, <https://www.veracrypt.fr/en/VeraCrypt%20Rescue%20Disk.html> <sup>[[Archive.org]][1147]</sup>
 
-[^348]: Wikipedia, Virtualbox <https://en.wikipedia.org/wiki/VirtualBox> <sup>[[Wikiless]][1153]</sup> <sup>[[Archive.org]][1154]</sup>
+[^348]: Wikipedia, Virtualbox, <https://en.wikipedia.org/wiki/VirtualBox> <sup>[[Wikiless]][1153]</sup> <sup>[[Archive.org]][1154]</sup>
 
-[^349]: VirtualBox Ticket 17987 <https://www.virtualbox.org/ticket/17987> <sup>[[Archive.org]][1155]</sup>
+[^349]: VirtualBox Ticket 17987, <https://www.virtualbox.org/ticket/17987> <sup>[[Archive.org]][1155]</sup>
 
-[^350]: Whonix Documentation, Spectre Meltdown <https://www.whonix.org/wiki/Spectre_Meltdown#VirtualBox> <sup>[[Archive.org]][82]</sup>
+[^350]: Whonix Documentation, Spectre Meltdown, <https://www.whonix.org/wiki/Spectre_Meltdown#VirtualBox> <sup>[[Archive.org]][82]</sup>
 
-[^351]: Whonix Documentation, Stream Isolation <https://www.whonix.org/wiki/Stream_Isolation> <sup>[[Archive.org]][316]</sup>
+[^351]: Whonix Documentation, Stream Isolation, <https://www.whonix.org/wiki/Stream_Isolation> <sup>[[Archive.org]][316]</sup>
 
-[^352]: Whonix Documentation, Tunnels Comparison Table <https://www.whonix.org/wiki/Tunnels/Introduction#Comparison_Table> <sup>[[Archive.org]][318]</sup>
+[^352]: Whonix Documentation, Tunnels Comparison Table, <https://www.whonix.org/wiki/Tunnels/Introduction#Comparison_Table> <sup>[[Archive.org]][318]</sup>
 
-[^353]: Wikipedia, Whonix <https://en.wikipedia.org/wiki/Whonix> <sup>[[Wikiless]][1156]</sup> <sup>[[Archive.org]][1157]</sup>
+[^353]: Wikipedia, Whonix, <https://en.wikipedia.org/wiki/Whonix> <sup>[[Wikiless]][1156]</sup> <sup>[[Archive.org]][1157]</sup>
 
-[^354]: Oracle Virtualbox Manual, Snapshots <https://docs.oracle.com/en/virtualization/virtualbox/6.0/user/snapshots.html> <sup>[[Archive.org]][1158]</sup>
+[^354]: Oracle Virtualbox Manual, Snapshots, <https://docs.oracle.com/en/virtualization/virtualbox/6.0/user/snapshots.html> <sup>[[Archive.org]][1158]</sup>
 
-[^355]: Utica College, Forensic Recovery Of Evidence From Deleted Oracle Virtualbox Virtual Machines <https://web.archive.org/web/https://programs.online.utica.edu/sites/default/files/Neal_6_Gonnella_Forensic_Recovery_of_Evidence_from_Deleted_Oracle_VirtualBox_Virtual_Machine.pdf>
+[^355]: Utica College, Forensic Recovery Of Evidence From Deleted Oracle Virtualbox Virtual Machines, <https://web.archive.org/web/https://programs.online.utica.edu/sites/default/files/Neal_6_Gonnella_Forensic_Recovery_of_Evidence_from_Deleted_Oracle_VirtualBox_Virtual_Machine.pdf>
 
-[^356]: Wikipedia, Spectre <https://en.wikipedia.org/wiki/Spectre_(security_vulnerability)> <sup>[[Wikiless]][1159]</sup> <sup>[[Archive.org]][1160]</sup>
+[^356]: Wikipedia, Spectre, <https://en.wikipedia.org/wiki/Spectre_(security_vulnerability)> <sup>[[Wikiless]][1159]</sup> <sup>[[Archive.org]][1160]</sup>
 
-[^357]: Wikipedia, Meltdown <https://en.wikipedia.org/wiki/Meltdown_(security_vulnerability)> <sup>[[Wikiless]][1161]</sup> <sup>[[Archive.org]][1162]</sup>
+[^357]: Wikipedia, Meltdown, <https://en.wikipedia.org/wiki/Meltdown_(security_vulnerability)> <sup>[[Wikiless]][1161]</sup> <sup>[[Archive.org]][1162]</sup>
 
-[^358]: Whonix Documentation, Stream Isolation, By Settings <https://www.whonix.org/wiki/Stream_Isolation#By_Settings> <sup>[[Archive.org]][1163]</sup>
+[^358]: Whonix Documentation, Stream Isolation, By Settings, <https://www.whonix.org/wiki/Stream_Isolation#By_Settings> <sup>[[Archive.org]][1163]</sup>
 
-[^359]: Wikipedia, TOTP <https://en.wikipedia.org/wiki/Time-based_One-time_Password_algorithm> <sup>[[Wikiless]][1164]</sup> <sup>[[Archive.org]][1165]</sup>
+[^359]: Wikipedia, TOTP, <https://en.wikipedia.org/wiki/Time-based_One-time_Password_algorithm> <sup>[[Wikiless]][1164]</sup> <sup>[[Archive.org]][1165]</sup>
 
-[^360]: Wikipedia, Multi-Factor Authentication <https://en.wikipedia.org/wiki/Multi-factor_authentication> <sup>[[Wikiless]][1166]</sup> <sup>[[Archive.org]][1167]</sup>
+[^360]: Wikipedia, Multi-Factor Authentication, <https://en.wikipedia.org/wiki/Multi-factor_authentication> <sup>[[Wikiless]][1166]</sup> <sup>[[Archive.org]][1167]</sup>
 
-[^361]: Whonix Documentation, Bridged Adapters Warning <https://www.whonix.org/wiki/Whonix-Gateway_Security#Warning:_Bridged_Networking> <sup>[[Archive.org]][1168]</sup>
+[^361]: Whonix Documentation, Bridged Adapters Warning, <https://www.whonix.org/wiki/Whonix-Gateway_Security#Warning:_Bridged_Networking> <sup>[[Archive.org]][1168]</sup>
 
 [^362]: Qubes OS, FAQ, <https://www.qubes-os.org/faq/#is-qubes-just-another-linux-distribution> <sup>[[Archive.org]][1169]</sup>
 
-[^363]: Qubes OS, System Requirements <https://www.qubes-os.org/doc/system-requirements/> <sup>[[Archive.org]][1170]</sup>
+[^363]: Qubes OS, System Requirements, <https://www.qubes-os.org/doc/system-requirements/> <sup>[[Archive.org]][1170]</sup>
 
-[^364]: Whonix Documentation, Stream Isolation <https://www.whonix.org/wiki/Stream_Isolation> <sup>[[Archive.org]][316]</sup>
+[^364]: Whonix Documentation, Stream Isolation, <https://www.whonix.org/wiki/Stream_Isolation> <sup>[[Archive.org]][316]</sup>
 
-[^365]: Whonix Documentation, Tunnels Comparison Table <https://www.whonix.org/wiki/Tunnels/Introduction#Comparison_Table> <sup>[[Archive.org]][318]</sup>
+[^365]: Whonix Documentation, Tunnels Comparison Table, <https://www.whonix.org/wiki/Tunnels/Introduction#Comparison_Table> <sup>[[Archive.org]][318]</sup>
 
-[^366]: Qubes OS Issues, Simulate Hibernation / Suspend-To-Disk (Issue #2414) <https://github.com/QubesOS/qubes-issues/issues/2414> <sup>[[Archive.org]][1171]</sup>
+[^366]: Qubes OS Issues, Simulate Hibernation / Suspend-To-Disk (Issue #2414), <https://github.com/QubesOS/qubes-issues/issues/2414> <sup>[[Archive.org]][1171]</sup>
 
-[^367]: Wikipedia, AppArmor <https://en.wikipedia.org/wiki/AppArmor> <sup>[[Wikiless]][1172]</sup> <sup>[[Archive.org]][1173]</sup>
+[^367]: Wikipedia, AppArmor, <https://en.wikipedia.org/wiki/AppArmor> <sup>[[Wikiless]][1172]</sup> <sup>[[Archive.org]][1173]</sup>
 
-[^368]: Wikipedia, SELinux <https://en.wikipedia.org/wiki/Security-Enhanced_Linux> <sup>[[Wikiless]][1174]</sup> <sup>[[Archive.org]][1175]</sup>
+[^368]: Wikipedia, SELinux, <https://en.wikipedia.org/wiki/Security-Enhanced_Linux> <sup>[[Wikiless]][1174]</sup> <sup>[[Archive.org]][1175]</sup>
 
-[^369]: Wikipedia, TOTP <https://en.wikipedia.org/wiki/Time-based_One-time_Password_algorithm> <sup>[[Wikiless]][1164]</sup> <sup>[[Archive.org]][1165]</sup>
+[^369]: Wikipedia, TOTP, <https://en.wikipedia.org/wiki/Time-based_One-time_Password_algorithm> <sup>[[Wikiless]][1164]</sup> <sup>[[Archive.org]][1165]</sup>
 
-[^370]: Wikipedia, Multi-Factor Authentication <https://en.wikipedia.org/wiki/Multi-factor_authentication> <sup>[[Wikiless]][1166]</sup> <sup>[[Archive.org]][1167]</sup>
+[^370]: Wikipedia, Multi-Factor Authentication, <https://en.wikipedia.org/wiki/Multi-factor_authentication> <sup>[[Wikiless]][1166]</sup> <sup>[[Archive.org]][1167]</sup>
 
-[^371]: Wikipedia, Captcha <https://en.wikipedia.org/wiki/CAPTCHA> <sup>[[Wikiless]][1176]</sup> <sup>[[Archive.org]][1177]</sup>
+[^371]: Wikipedia, Captcha, <https://en.wikipedia.org/wiki/CAPTCHA> <sup>[[Wikiless]][1176]</sup> <sup>[[Archive.org]][1177]</sup>
 
-[^372]: Wikipedia, Turing Test <https://en.wikipedia.org/wiki/Turing_test> <sup>[[Wikiless]][1178]</sup> <sup>[[Archive.org]][1179]</sup>
+[^372]: Wikipedia, Turing Test, <https://en.wikipedia.org/wiki/Turing_test> <sup>[[Wikiless]][1178]</sup> <sup>[[Archive.org]][1179]</sup>
 
-[^373]: Google reCAPTCHA <https://www.google.com/recaptcha/about/> <sup>[[Archive.org]][1180]</sup>
+[^373]: Google reCAPTCHA, <https://www.google.com/recaptcha/about/> <sup>[[Archive.org]][1180]</sup>
 
-[^374]: hCaptcha <https://www.hcaptcha.com/> <sup>[[Archive.org]][1181]</sup>
+[^374]: hCaptcha, <https://www.hcaptcha.com/> <sup>[[Archive.org]][1181]</sup>
 
-[^375]: hCaptcha, hCaptcha Is Now the Largest Independent CAPTCHA Service, Runs on 15% Of The Internet <https://www.hcaptcha.com/post/hcaptcha-now-the-largest-independent-captcha-service> <sup>[[Archive.org]][1182]</sup>
+[^375]: hCaptcha, hCaptcha Is Now the Largest Independent CAPTCHA Service, Runs on 15% Of The Internet, <https://www.hcaptcha.com/post/hcaptcha-now-the-largest-independent-captcha-service> <sup>[[Archive.org]][1182]</sup>
 
-[^376]: Nearcyan.com, You (probably) don't need ReCAPTCHA <https://nearcyan.com/you-probably-dont-need-recaptcha/> <sup>[[Archive.org]][1183]</sup>
+[^376]: Nearcyan.com, You (probably) don't need ReCAPTCHA, <https://nearcyan.com/you-probably-dont-need-recaptcha/> <sup>[[Archive.org]][1183]</sup>
 
-[^377]: ArsTechnica, "Google's reCAPTCHA turns "invisible," will separate bots from people without challenges" <https://arstechnica.com/gadgets/2017/03/googles-recaptcha-announces-invisible-background-captchas/> <sup>[[Archive.org]][1184]</sup>
+[^377]: ArsTechnica, "Google's reCAPTCHA turns "invisible," will separate bots from people without challenges", <https://arstechnica.com/gadgets/2017/03/googles-recaptcha-announces-invisible-background-captchas/> <sup>[[Archive.org]][1184]</sup>
 
-[^378]: BlackHat Asia 2016, "I'm not a human: Breaking the Google reCAPTCHA" <https://www.blackhat.com/docs/asia-16/materials/asia-16-Sivakorn-Im-Not-a-Human-Breaking-the-Google-reCAPTCHA-wp.pdf> <sup>[[Archive.org]][1185]</sup>
+[^378]: BlackHat Asia 2016, "I'm not a human: Breaking the Google reCAPTCHA", <https://www.blackhat.com/docs/asia-16/materials/asia-16-Sivakorn-Im-Not-a-Human-Breaking-the-Google-reCAPTCHA-wp.pdf> <sup>[[Archive.org]][1185]</sup>
 
-[^379]: Google Blog <https://security.googleblog.com/2014/12/are-you-robot-introducing-no-captcha.html> <sup>[[Archive.org]][1186]</sup>
+[^379]: Google Blog, <https://security.googleblog.com/2014/12/are-you-robot-introducing-no-captcha.html> <sup>[[Archive.org]][1186]</sup>
 
-[^380]: Cloudflare Blog, Cloudflare supports Privacy Pass <https://blog.cloudflare.com/cloudflare-supports-privacy-pass/> <sup>[[Archive.org]][1187]</sup>
+[^380]: Cloudflare Blog, Cloudflare supports Privacy Pass, <https://blog.cloudflare.com/cloudflare-supports-privacy-pass/> <sup>[[Archive.org]][1187]</sup>
 
-[^381]: Privacy International, Timeline of SIM Card Registration Laws <https://privacyinternational.org/long-read/3018/timeline-sim-card-registration-laws> <sup>[[Archive.org]][1105]</sup>
+[^381]: Privacy International, Timeline of SIM Card Registration Laws, <https://privacyinternational.org/long-read/3018/timeline-sim-card-registration-laws> <sup>[[Archive.org]][1105]</sup>
 
-[^382]: Wikipedia, Device Fingerprinting <https://en.wikipedia.org/wiki/Device_fingerprint> <sup>[[Wikiless]][1188]</sup> <sup>[[Archive.org]][1189]</sup>
+[^382]: Wikipedia, Device Fingerprinting, <https://en.wikipedia.org/wiki/Device_fingerprint> <sup>[[Wikiless]][1188]</sup> <sup>[[Archive.org]][1189]</sup>
 
-[^383]: Developers Google Blog, Guidance to developers affected by our effort to block less secure browsers and applications <https://developers.googleblog.com/2020/08/guidance-for-our-effort-to-block-less-secure-browser-and-apps.html> <sup>[[Archive.org]][1190]</sup>
+[^383]: Developers Google Blog, Guidance to developers affected by our effort to block less secure browsers and applications, <https://developers.googleblog.com/2020/08/guidance-for-our-effort-to-block-less-secure-browser-and-apps.html> <sup>[[Archive.org]][1190]</sup>
 
-[^384]: Google Help, Access age-restricted content & features <https://support.google.com/accounts/answer/10071085> <sup>[[Archive.org]][1191]</sup>
+[^384]: Google Help, Access age-restricted content & features, <https://support.google.com/accounts/answer/10071085> <sup>[[Archive.org]][1191]</sup>
 
-[^385]: Wikipedia, Dark Pattern <https://en.wikipedia.org/wiki/Dark_pattern> <sup>[[Wikiless]][1192]</sup> <sup>[[Archive.org]][1193]</sup>
+[^385]: Wikipedia, Dark Pattern, <https://en.wikipedia.org/wiki/Dark_pattern> <sup>[[Wikiless]][1192]</sup> <sup>[[Archive.org]][1193]</sup>
 
-[^386]: The Verge, Tinder will give you a verified blue check mark if you pass its catfishing test <https://www.theverge.com/2020/1/23/21077423/tinder-photo-verification-blue-checkmark-safety-center-launch-noonlight> <sup>[[Archive.org]][1194]</sup>
+[^386]: The Verge, Tinder will give you a verified blue check mark if you pass its catfishing test, <https://www.theverge.com/2020/1/23/21077423/tinder-photo-verification-blue-checkmark-safety-center-launch-noonlight> <sup>[[Archive.org]][1194]</sup>
 
-[^387]: DigitalInformationWorld, Facebook will now require you to Create a Video Selfie for Identity Verification <https://www.digitalinformationworld.com/2020/03/facebook-is-now-demanding-some-users-to-create-a-video-selfie-for-identity-verification.html> <sup>[[Archive.org]][1195]</sup>
+[^387]: DigitalInformationWorld, Facebook will now require you to Create a Video Selfie for Identity Verification, <https://www.digitalinformationworld.com/2020/03/facebook-is-now-demanding-some-users-to-create-a-video-selfie-for-identity-verification.html> <sup>[[Archive.org]][1195]</sup>
 
-[^388]: Vice.com, PornHub Announces 'Biometric Technology' to Verify Users <https://www.vice.com/en/article/m7a4eq/pornhub-new-verification-policy-biometric-id> <sup>[[Archive.org]][1196]</sup>
+[^388]: Vice.com, PornHub Announces 'Biometric Technology' to Verify Users, <https://www.vice.com/en/article/m7a4eq/pornhub-new-verification-policy-biometric-id> <sup>[[Archive.org]][1196]</sup>
 
-[^389]: Variety, China Launches Hotline to Report Online Comments That 'Distort' History or 'Deny' Its Cultural Excellence <https://variety.com/2021/digital/news/china-censorship-hotline-historical-nihilism-1234950554/> <sup>[[Archive.org]][1197]</sup>
+[^389]: Variety, China Launches Hotline to Report Online Comments That 'Distort' History or 'Deny' Its Cultural Excellence, <https://variety.com/2021/digital/news/china-censorship-hotline-historical-nihilism-1234950554/> <sup>[[Archive.org]][1197]</sup>
 
-[^390]: Wikipedia, Trust but verify <https://en.wikipedia.org/wiki/Trust,_but_verify> <sup>[[Wikiless]][776]</sup> <sup>[[Archive.org]][777]</sup>
+[^390]: Wikipedia, Trust but verify, <https://en.wikipedia.org/wiki/Trust,_but_verify> <sup>[[Wikiless]][776]</sup> <sup>[[Archive.org]][777]</sup>
 
-[^391]: Wikipedia, Zero-trust Security Model <https://en.wikipedia.org/wiki/Zero_trust_security_model> <sup>[[Wikiless]][1198]</sup> <sup>[[Archive.org]][1199]</sup>
+[^391]: Wikipedia, Zero-trust Security Model, <https://en.wikipedia.org/wiki/Zero_trust_security_model> <sup>[[Wikiless]][1198]</sup> <sup>[[Archive.org]][1199]</sup>
 
-[^392]: Wikipedia, Espionage, Organization <https://en.wikipedia.org/wiki/Espionage#Organization> <sup>[[Wikiless]][1200]</sup> <sup>[[Archive.org]][1201]</sup>
+[^392]: Wikipedia, Espionage, Organization, <https://en.wikipedia.org/wiki/Espionage#Organization> <sup>[[Wikiless]][1200]</sup> <sup>[[Archive.org]][1201]</sup>
 
-[^393]: Medium.com, Kyle McDonald, How to recognize fake AI-generated images <https://kcimc.medium.com/how-to-recognize-fake-ai-generated-images-4d1f6f9a2842><sup>[[Scribe.rip]][1202]</sup> <sup>[[Archive.org]][1203]</sup>
+[^393]: Medium.com, Kyle McDonald, How to recognize fake AI-generated images, <https://kcimc.medium.com/how-to-recognize-fake-ai-generated-images-4d1f6f9a2842><sup>[[Scribe.rip]][1202]</sup> <sup>[[Archive.org]][1203]</sup>
 
-[^394]: Jayway Blog, Using ML to detect fake face images created by AI <https://blog.jayway.com/2020/03/06/using-ml-to-detect-fake-face-images-created-by-ai/> <sup>[[Archive.org]][1204]</sup>
+[^394]: Jayway Blog, Using ML to detect fake face images created by AI, <https://blog.jayway.com/2020/03/06/using-ml-to-detect-fake-face-images-created-by-ai/> <sup>[[Archive.org]][1204]</sup>
 
-[^395]: Wikipedia, Sim Swapping <https://en.wikipedia.org/wiki/SIM_swap_scam> <sup>[[Wikiless]][1205]</sup> <sup>[[Archive.org]][1206]</sup>
+[^395]: Wikipedia, Sim Swapping, <https://en.wikipedia.org/wiki/SIM_swap_scam> <sup>[[Wikiless]][1205]</sup> <sup>[[Archive.org]][1206]</sup>
 
-[^396]: Whonix Documentation, Tor Configuration <https://www.whonix.org/wiki/Tor#Edit_Tor_Configuration> <sup>[[Archive.org]][1207]</sup>
+[^396]: Whonix Documentation, Tor Configuration, <https://www.whonix.org/wiki/Tor#Edit_Tor_Configuration> <sup>[[Archive.org]][1207]</sup>
 
-[^397]: Tor Browser Documentation, Editing Torrc <https://support.torproject.org/tbb/tbb-editing-torrc/> <sup>[[Archive.org]][1208]</sup>
+[^397]: Tor Browser Documentation, Editing Torrc, <https://support.torproject.org/tbb/tbb-editing-torrc/> <sup>[[Archive.org]][1208]</sup>
 
 [^398]: Facebook Onion Website <http://facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion/>
 
-[^399]: Google Help <https://support.google.com/accounts/answer/114129?hl=en> <sup>[[Archive.org]][1209]</sup>
+[^399]: Google Help, <https://support.google.com/accounts/answer/114129?hl=en> <sup>[[Archive.org]][1209]</sup>
 
-[^400]: Google Help, Customer Matching Process <https://support.google.com/google-ads/answer/7474263?hl=en> <sup>[[Archive.org]][1210]</sup>
+[^400]: Google Help, Customer Matching Process, <https://support.google.com/google-ads/answer/7474263?hl=en> <sup>[[Archive.org]][1210]</sup>
 
-[^401]: Google, Your account is disabled <https://support.google.com/accounts/answer/40695> <sup>[[Archive.org]][1211]</sup>
+[^401]: Google, Your account is disabled, <https://support.google.com/accounts/answer/40695> <sup>[[Archive.org]][1211]</sup>
 
-[^402]: Google, Request to restore the account <https://support.google.com/accounts/contact/disabled2> <sup>[[Archive.org]][1212]</sup>
+[^402]: Google, Request to restore the account, <https://support.google.com/accounts/contact/disabled2> <sup>[[Archive.org]][1212]</sup>
 
-[^403]: Google Help, Update your account to meet age requirements <https://support.google.com/accounts/answer/1333913?hl=en> <sup>[[Archive.org]][1213]</sup>
+[^403]: Google Help, Update your account to meet age requirements, <https://support.google.com/accounts/answer/1333913?hl=en> <sup>[[Archive.org]][1213]</sup>
 
-[^404]: Jumio, ID verification features <https://www.jumio.com/features/> <sup>[[Archive.org]][1214]</sup>
+[^404]: Jumio, ID verification features, <https://www.jumio.com/features/> <sup>[[Archive.org]][1214]</sup>
 
-[^405]: Privacyguides.org recommended E-mail Providers <https://www.privacyguides.org/email/> <sup>[[Archive.org]][1215]</sup>
+[^405]: Privacyguides.org recommended E-mail Providers, <https://www.privacyguides.org/email/> <sup>[[Archive.org]][1215]</sup>
 
-[^406]: ProtonMail Registration Human Verification <https://protonmail.com/support/knowledge-base/human-verification/> <sup>[[Archive.org]][1216]</sup>
+[^406]: ProtonMail Registration Human Verification, <https://protonmail.com/support/knowledge-base/human-verification/> <sup>[[Archive.org]][1216]</sup>
 
-[^407]: Twitter Appeal Form <https://help.twitter.com/forms/general>
+[^407]: Twitter Appeal Form, <https://help.twitter.com/forms/general>
 
-[^408]: KnowYourMeme, Good Luck, I'm Behind 7 Proxies <https://knowyourmeme.com/memes/good-luck-im-behind-7-proxies> <sup>[[Archive.org]][1217]</sup>
+[^408]: KnowYourMeme, Good Luck, I'm Behind 7 Proxies, <https://knowyourmeme.com/memes/good-luck-im-behind-7-proxies> <sup>[[Archive.org]][1217]</sup>
 
-[^409]: Wikipedia, end-to-end encryption <https://en.wikipedia.org/wiki/End-to-end_encryption> <sup>[[Wikiless]][1218]</sup> <sup>[[Archive.org]][1219]</sup>
+[^409]: Wikipedia, end-to-end encryption, <https://en.wikipedia.org/wiki/End-to-end_encryption> <sup>[[Wikiless]][1218]</sup> <sup>[[Archive.org]][1219]</sup>
 
-[^410]: Wikipedia, Forward Secrecy <https://en.wikipedia.org/wiki/Forward_secrecy> <sup>[[Wikiless]][1220]</sup> <sup>[[Archive.org]][1221]</sup>
+[^410]: Wikipedia, Forward Secrecy, <https://en.wikipedia.org/wiki/Forward_secrecy> <sup>[[Wikiless]][1220]</sup> <sup>[[Archive.org]][1221]</sup>
 
-[^411]: Protonblog, What is zero-access encryption? <https://protonmail.com/blog/zero-access-encryption/> <sup>[[Archive.org]][1222]</sup>
+[^411]: Protonblog, What is zero-access encryption?, <https://protonmail.com/blog/zero-access-encryption/> <sup>[[Archive.org]][1222]</sup>
 
-[^412]: Wikipedia, Cambridge Analytica Scandal <https://en.wikipedia.org/wiki/Facebook%E2%80%93Cambridge_Analytica_data_scandal> <sup>[[Wikiless]][1223]</sup> <sup>[[Archive.org]][1224]</sup>
+[^412]: Wikipedia, Cambridge Analytica Scandal, <https://en.wikipedia.org/wiki/Facebook%E2%80%93Cambridge_Analytica_data_scandal> <sup>[[Wikiless]][1223]</sup> <sup>[[Archive.org]][1224]</sup>
 
-[^413]: Signal Blog, Technology preview: Sealed sender for Signal <https://signal.org/blog/sealed-sender/> <sup>[[Archive.org]][1225]</sup>
+[^413]: Signal Blog, Technology preview: Sealed sender for Signal, <https://signal.org/blog/sealed-sender/> <sup>[[Archive.org]][1225]</sup>
 
-[^414]: Signal Blog, Private Contact Discovery <https://signal.org/blog/private-contact-discovery/> <sup>[[Archive.org]][1226]</sup>
+[^414]: Signal Blog, Private Contact Discovery, <https://signal.org/blog/private-contact-discovery/> <sup>[[Archive.org]][1226]</sup>
 
-[^415]: Signal Blog, Private Group System <https://signal.org/blog/signal-private-group-system/> <sup>[[Archive.org]][1227]</sup>
+[^415]: Signal Blog, Private Group System, <https://signal.org/blog/signal-private-group-system/> <sup>[[Archive.org]][1227]</sup>
 
-[^416]: Privacyguides.org, File-Sharing <https://www.privacyguides.org/file-sharing/> <sup>[[Archive.org]][1228]</sup>
+[^416]: Privacyguides.org, File-Sharing, <https://www.privacyguides.org/file-sharing/> <sup>[[Archive.org]][1228]</sup>
 
-[^417]: Privacyguides.org, Real-Time Communication <https://www.privacyguides.org/real-time-communication/> <sup>[[Archive.org]][1229]</sup>
+[^417]: Privacyguides.org, Real-Time Communication, <https://www.privacyguides.org/real-time-communication/> <sup>[[Archive.org]][1229]</sup>
 
-[^418]: GetSession.org, The Session Protocol: What's changing --- and why <https://getsession.org/session-protocol-explained/> <sup>[[Archive.org]][1230]</sup>
+[^418]: GetSession.org, The Session Protocol: What's changing --- and why, <https://getsession.org/session-protocol-explained/> <sup>[[Archive.org]][1230]</sup>
 
-[^419]: Quarkslab, Audit of Session Secure Messaging Application <https://blog.quarkslab.com/audit-of-session-secure-messaging-application.html> <sup>[[Archive.org]][1231]</sup>
+[^419]: Quarkslab, Audit of Session Secure Messaging Application, <https://blog.quarkslab.com/audit-of-session-secure-messaging-application.html> <sup>[[Archive.org]][1231]</sup>
 
-[^420]: Techlore, Top 5 BEST Messengers For Privacy <https://www.youtube.com/watch?v=aVwl892hqb4> <sup>[[Invidious]][1232]</sup>
+[^420]: Techlore, Top 5 BEST Messengers For Privacy, <https://www.youtube.com/watch?v=aVwl892hqb4> <sup>[[Invidious]][1232]</sup>
 
-[^421]: Wikipedia, IPFS <https://en.wikipedia.org/wiki/InterPlanetary_File_System> <sup>[[Wikiless]][1233]</sup> <sup>[[Archive.org]][1234]</sup>
+[^421]: Wikipedia, IPFS, <https://en.wikipedia.org/wiki/InterPlanetary_File_System> <sup>[[Wikiless]][1233]</sup> <sup>[[Archive.org]][1234]</sup>
 
-[^422]: Praxis Films, Open Letter from Laura Poitras <https://www.praxisfilms.org/open-letter-from-laura-poitras/> <sup>[[Archive.org]][1235]</sup>
+[^422]: Praxis Films, Open Letter from Laura Poitras, <https://www.praxisfilms.org/open-letter-from-laura-poitras/> <sup>[[Archive.org]][1235]</sup>
 
-[^423]: Wikipedia, SecureDrop <https://en.wikipedia.org/wiki/SecureDrop> <sup>[[Wikiless]][1236]</sup> <sup>[[Archive.org]][1237]</sup>
+[^423]: Wikipedia, SecureDrop, <https://en.wikipedia.org/wiki/SecureDrop> <sup>[[Wikiless]][1236]</sup> <sup>[[Archive.org]][1237]</sup>
 
-[^424]: Wikipedia, TPM <https://en.wikipedia.org/wiki/Trusted_Platform_Module> <sup>[[Wikiless]][1238]</sup> <sup>[[Archive.org]][1239]</sup>
+[^424]: Wikipedia, TPM, <https://en.wikipedia.org/wiki/Trusted_Platform_Module> <sup>[[Wikiless]][1238]</sup> <sup>[[Archive.org]][1239]</sup>
 
-[^425]: Wikipedia, Pastebin <https://en.wikipedia.org/wiki/Pastebin> <sup>[[Wikiless]][1240]</sup> <sup>[[Archive.org]][1241]</sup>
+[^425]: Wikipedia, Pastebin, <https://en.wikipedia.org/wiki/Pastebin> <sup>[[Wikiless]][1240]</sup> <sup>[[Archive.org]][1241]</sup>
 
-[^426]: Wikipedia, Wear Leveling <https://en.wikipedia.org/wiki/Wear_leveling> <sup>[[Wikiless]][1242]</sup> <sup>[[Archive.org]][1243]</sup>
+[^426]: Wikipedia, Wear Leveling, <https://en.wikipedia.org/wiki/Wear_leveling> <sup>[[Wikiless]][1242]</sup> <sup>[[Archive.org]][1243]</sup>
 
-[^427]: Wikipedia, Trim <https://en.wikipedia.org/wiki/Write_amplification#TRIM> <sup>[[Wikiless]][1244]</sup> <sup>[[Archive.org]][1245]</sup>
+[^427]: Wikipedia, Trim, <https://en.wikipedia.org/wiki/Write_amplification#TRIM> <sup>[[Wikiless]][1244]</sup> <sup>[[Archive.org]][1245]</sup>
 
-[^428]: Wikipedia, Write Amplification <https://en.wikipedia.org/wiki/Write_amplification> <sup>[[Wikiless]][1244]</sup> <sup>[[Archive.org]][1245]</sup>
+[^428]: Wikipedia, Write Amplification, <https://en.wikipedia.org/wiki/Write_amplification> <sup>[[Wikiless]][1244]</sup> <sup>[[Archive.org]][1245]</sup>
 
-[^429]: Wikipedia, Trim Disadvantages <https://en.wikipedia.org/wiki/Trim_(computing)#Disadvantages> <sup>[[Wikiless]][485]</sup> <sup>[[Archive.org]][486]</sup>
+[^429]: Wikipedia, Trim Disadvantages, <https://en.wikipedia.org/wiki/Trim_(computing)#Disadvantages> <sup>[[Wikiless]][485]</sup> <sup>[[Archive.org]][486]</sup>
 
-[^430]: Wikipedia, Garbage Collection <https://en.wikipedia.org/wiki/Write_amplification#Garbage_collection> <sup>[[Wikiless]][1244]</sup> <sup>[[Archive.org]][1245]</sup>
+[^430]: Wikipedia, Garbage Collection, <https://en.wikipedia.org/wiki/Write_amplification#Garbage_collection> <sup>[[Wikiless]][1244]</sup> <sup>[[Archive.org]][1245]</sup>
 
-[^431]: Techgage, Too TRIM? When SSD Data Recovery is Impossible <https://techgage.com/article/too_trim_when_ssd_data_recovery_is_impossible/> <sup>[[Archive.org]][1246]</sup>
+[^431]: Techgage, Too TRIM? When SSD Data Recovery is Impossible, <https://techgage.com/article/too_trim_when_ssd_data_recovery_is_impossible/> <sup>[[Archive.org]][1246]</sup>
 
-[^432]: ResearchGate, Live forensics method for acquisition on the Solid-State Drive (SSD) NVMe TRIM function <https://www.researchgate.net/publication/341761017_Live_forensics_method_for_acquisition_on_the_Solid_State_Drive_SSD_NVMe_TRIM_function> <sup>[[Archive.org]][1247]</sup>
+[^432]: ResearchGate, Live forensics method for acquisition on the Solid-State Drive (SSD) NVMe TRIM function, <https://www.researchgate.net/publication/341761017_Live_forensics_method_for_acquisition_on_the_Solid_State_Drive_SSD_NVMe_TRIM_function> <sup>[[Archive.org]][1247]</sup>
 
-[^433]: ElcomSoft, Life after Trim: Using Factory Access Mode for Imaging SSD Drives <https://blog.elcomsoft.com/2019/01/life-after-trim-using-factory-access-mode-for-imaging-ssd-drives/> <sup>[[Archive.org]][1248]</sup>
+[^433]: ElcomSoft, Life after Trim: Using Factory Access Mode for Imaging SSD Drives, <https://blog.elcomsoft.com/2019/01/life-after-trim-using-factory-access-mode-for-imaging-ssd-drives/> <sup>[[Archive.org]][1248]</sup>
 
-[^434]: Forensic Focus, Forensic Acquisition Of Solid State Drives With Open Source Tools <https://www.forensicfocus.com/articles/forensic-acquisition-of-solid-state-drives-with-open-source-tools/> <sup>[[Archive.org]][1249]</sup>
+[^434]: Forensic Focus, Forensic Acquisition Of Solid State Drives With Open Source Tools, <https://www.forensicfocus.com/articles/forensic-acquisition-of-solid-state-drives-with-open-source-tools/> <sup>[[Archive.org]][1249]</sup>
 
-[^435]: ResearchGate, Solid State Drive Forensics: Where Do We Stand? <https://www.researchgate.net/publication/325976653_Solid_State_Drive_Forensics_Where_Do_We_Stand> <sup>[[Archive.org]][1250]</sup>
+[^435]: ResearchGate, Solid State Drive Forensics: Where Do We Stand?, <https://www.researchgate.net/publication/325976653_Solid_State_Drive_Forensics_Where_Do_We_Stand> <sup>[[Archive.org]][1250]</sup>
 
-[^436]: BleepingComputer, Firmware attack can drop persistent malware in hidden SSD area <https://www.bleepingcomputer.com/news/security/firmware-attack-can-drop-persistent-malware-in-hidden-ssd-area/> <sup>[[Archive.org]][1251]</sup>
+[^436]: BleepingComputer, Firmware attack can drop persistent malware in hidden SSD area, <https://www.bleepingcomputer.com/news/security/firmware-attack-can-drop-persistent-malware-in-hidden-ssd-area/> <sup>[[Archive.org]][1251]</sup>
 
-[^437]: Wikipedia, Parted Magic <https://en.wikipedia.org/wiki/Parted_Magic> <sup>[[Wikiless]][1252]</sup> <sup>[[Archive.org]][1253]</sup>
+[^437]: Wikipedia, Parted Magic, <https://en.wikipedia.org/wiki/Parted_Magic> <sup>[[Wikiless]][1252]</sup> <sup>[[Archive.org]][1253]</sup>
 
-[^438]: Wikipedia, hdparm <https://en.wikipedia.org/wiki/Hdparm> <sup>[[Wikiless]][1254]</sup> <sup>[[Archive.org]][1255]</sup>
+[^438]: Wikipedia, hdparm, <https://en.wikipedia.org/wiki/Hdparm> <sup>[[Wikiless]][1254]</sup> <sup>[[Archive.org]][1255]</sup>
 
-[^439]: GitHub, nvme-cli <https://github.com/linux-nvme/nvme-cli> <sup>[[Archive.org]][1256]</sup>
+[^439]: GitHub, nvme-cli, <https://github.com/linux-nvme/nvme-cli> <sup>[[Archive.org]][1256]</sup>
 
-[^440]: PartedMagic Secure Erase <https://partedmagic.com/secure-erase/> <sup>[[Archive.org]][1257]</sup>
+[^440]: PartedMagic Secure Erase, <https://partedmagic.com/secure-erase/> <sup>[[Archive.org]][1257]</sup>
 
-[^441]: Partedmagic NVMe Secure Erase <https://partedmagic.com/nvme-secure-erase/> <sup>[[Archive.org]][1258]</sup>
+[^441]: Partedmagic NVMe Secure Erase, <https://partedmagic.com/nvme-secure-erase/> <sup>[[Archive.org]][1258]</sup>
 
-[^442]: UFSExplorer, Can I recover data from an encrypted storage? <https://www.ufsexplorer.com/solutions/data-recovery-on-encrypted-storage.php> <sup>[[Archive.org]][1259]</sup>
+[^442]: UFSExplorer, Can I recover data from an encrypted storage?, <https://www.ufsexplorer.com/solutions/data-recovery-on-encrypted-storage.php> <sup>[[Archive.org]][1259]</sup>
 
-[^443]: Apple Developer Documentation <https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/APFS_Guide/FAQ/FAQ.html> <sup>[[Archive.org]][1260]</sup>
+[^443]: Apple Developer Documentation, <https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/APFS_Guide/FAQ/FAQ.html> <sup>[[Archive.org]][1260]</sup>
 
-[^444]: EFF, How to: Delete Your Data Securely on macOS <https://ssd.eff.org/en/module/how-delete-your-data-securely-macos> <sup>[[Archive.org]][508]</sup>
+[^444]: EFF, How to: Delete Your Data Securely on macOS, <https://ssd.eff.org/en/module/how-delete-your-data-securely-macos> <sup>[[Archive.org]][508]</sup>
 
-[^445]: Privacyguides.org, Productivity tools <https://privacyguides.org/productivity/> <sup>[[Archive.org]][1261]</sup>
+[^445]: Privacyguides.org, Productivity tools, <https://privacyguides.org/productivity/> <sup>[[Archive.org]][1261]</sup>
 
-[^446]: Whonix Documentation, Scrubbing Metadata <https://www.whonix.org/wiki/Metadata> <sup>[[Archive.org]][1262]</sup>
+[^446]: Whonix Documentation, Scrubbing Metadata, <https://www.whonix.org/wiki/Metadata> <sup>[[Archive.org]][1262]</sup>
 
-[^447]: Tails documentation, MAT <https://gitlab.tails.boum.org/tails/blueprints/-/wikis/doc/mat/> <sup>[[Archive.org]][1263]</sup>
+[^447]: Tails documentation, MAT, <https://gitlab.tails.boum.org/tails/blueprints/-/wikis/doc/mat/> <sup>[[Archive.org]][1263]</sup>
 
-[^448]: GitHub, Disable Gatekeeper on macOS Big Sur (11.x) <https://disable-gatekeeper.github.io/> <sup>[[Archive.org]][1264]</sup>
+[^448]: GitHub, Disable Gatekeeper on macOS Big Sur (11.x), <https://disable-gatekeeper.github.io/> <sup>[[Archive.org]][1264]</sup>
 
-[^449]: DuckDuckGo help, Cache <https://help.duckduckgo.com/duckduckgo-help-pages/features/cache/> <sup>[[Archive.org]][1265]</sup>
+[^449]: DuckDuckGo help, Cache, <https://help.duckduckgo.com/duckduckgo-help-pages/features/cache/> <sup>[[Archive.org]][1265]</sup>
 
-[^450]: DuckDuckGo help, Sources <https://help.duckduckgo.com/duckduckgo-help-pages/results/sources/> <sup>[[Archive.org]][1266]</sup>
+[^450]: DuckDuckGo help, Sources, <https://help.duckduckgo.com/duckduckgo-help-pages/results/sources/> <sup>[[Archive.org]][1266]</sup>
 
-[^451]: Wikipedia, Dead Drop <https://en.wikipedia.org/wiki/Dead_drop> <sup>[[Wikiless]][1267]</sup> <sup>[[Archive.org]][1268]</sup>
+[^451]: Wikipedia, Dead Drop, <https://en.wikipedia.org/wiki/Dead_drop> <sup>[[Wikiless]][1267]</sup> <sup>[[Archive.org]][1268]</sup>
 
-[^452]: Wikipedia, Secure Communication Obfuscation <https://en.wikipedia.org/wiki/Obfuscation#Secure_communication> <sup>[[Wikiless]][1269]</sup> <sup>[[Archive.org]][1270]</sup>
+[^452]: Wikipedia, Secure Communication Obfuscation, <https://en.wikipedia.org/wiki/Obfuscation#Secure_communication> <sup>[[Wikiless]][1269]</sup> <sup>[[Archive.org]][1270]</sup>
 
-[^453]: Wikipedia, Steganography <https://en.wikipedia.org/wiki/Steganography> <sup>[[Wikiless]][1024]</sup> <sup>[[Archive.org]][1025]</sup>
+[^453]: Wikipedia, Steganography, <https://en.wikipedia.org/wiki/Steganography> <sup>[[Wikiless]][1024]</sup> <sup>[[Archive.org]][1025]</sup>
 
-[^454]: Wikipedia, Kleptography <https://en.wikipedia.org/wiki/Kleptography> <sup>[[Wikiless]][1271]</sup> <sup>[[Archive.org]][1272]</sup>
+[^454]: Wikipedia, Kleptography, <https://en.wikipedia.org/wiki/Kleptography> <sup>[[Wikiless]][1271]</sup> <sup>[[Archive.org]][1272]</sup>
 
-[^455]: Wikipedia, Koalang <https://en.wikipedia.org/wiki/Koalang> <sup>[[Wikiless]][1273]</sup> <sup>[[Archive.org]][1274]</sup>
+[^455]: Wikipedia, Koalang, <https://en.wikipedia.org/wiki/Koalang> <sup>[[Wikiless]][1273]</sup> <sup>[[Archive.org]][1274]</sup>
 
-[^456]: Wikipedia, OPSEC <https://en.wikipedia.org/wiki/Operations_security> <sup>[[Wikiless]][1275]</sup> <sup>[[Archive.org]][1276]</sup>
+[^456]: Wikipedia, OPSEC, <https://en.wikipedia.org/wiki/Operations_security> <sup>[[Wikiless]][1275]</sup> <sup>[[Archive.org]][1276]</sup>
 
-[^457]: Quote Investigator, A Lie Can Travel Halfway Around the World While the Truth Is Putting On Its Shoes <https://quoteinvestigator.com/2014/07/13/truth/> <sup>[[Archive.org]][1277]</sup>
+[^457]: Quote Investigator, A Lie Can Travel Halfway Around the World While the Truth Is Putting On Its Shoes, <https://quoteinvestigator.com/2014/07/13/truth/> <sup>[[Archive.org]][1277]</sup>
 
-[^458]: Privacyguides.org, Operating Systems <https://www.privacyguides.org/tools/#operating-systems> <sup>[[Archive.org]][1278]</sup>
+[^458]: Privacyguides.org, Operating Systems, <https://www.privacyguides.org/tools/#operating-systems> <sup>[[Archive.org]][1278]</sup>
 
-[^459]: Brave Support, What is a Private Window with Tor? <https://support.brave.com/hc/en-us/articles/360018121491-What-is-a-Private-Window-with-Tor> <sup>[[Archive.org]][1279]</sup>
+[^459]: Brave Support, What is a Private Window with Tor?, <https://support.brave.com/hc/en-us/articles/360018121491-What-is-a-Private-Window-with-Tor> <sup>[[Archive.org]][1279]</sup>
 
-[^460]: Medium.com, The Windows USN Journal <https://medium.com/velociraptor-ir/the-windows-usn-journal-f0c55c9010e> <sup>[[Scribe.rip]][1280]</sup> <sup>[[Archive.org]][1281]</sup>
+[^460]: Medium.com, The Windows USN Journal, <https://medium.com/velociraptor-ir/the-windows-usn-journal-f0c55c9010e> <sup>[[Scribe.rip]][1280]</sup> <sup>[[Archive.org]][1281]</sup>
 
-[^461]: Medium.com, Digging into the System Resource Usage Monitor (SRUM) <https://medium.com/velociraptor-ir/digging-into-the-system-resource-usage-monitor-srum-afbadb1a375> <sup>[[Scribe.rip]][1282]</sup> <sup>[[Archive.org]][1283]</sup>
+[^461]: Medium.com, Digging into the System Resource Usage Monitor (SRUM), <https://medium.com/velociraptor-ir/digging-into-the-system-resource-usage-monitor-srum-afbadb1a375> <sup>[[Scribe.rip]][1282]</sup> <sup>[[Archive.org]][1283]</sup>
 
-[^462]: SANS, Timestamped Registry & NTFS Artifacts from Unallocated Space <https://www.sans.org/blog/timestamped-registry-ntfs-artifacts-from-unallocated-space/> <sup>[[Archive.org]][1284]</sup>
+[^462]: SANS, Timestamped Registry & NTFS Artifacts from Unallocated Space, <https://www.sans.org/blog/timestamped-registry-ntfs-artifacts-from-unallocated-space/> <sup>[[Archive.org]][1284]</sup>
 
 [^463]: DBAN, <https://dban.org/> <sup>[[Archive.org]][1285]</sup>
 
-[^464]: NYTimes, Lost Passwords Lock Millionaires Out of Their Bitcoin Fortunes <https://www.nytimes.com/2021/01/12/technology/bitcoin-passwords-wallets-fortunes.html> <sup>[[Archive.org]][1106]</sup>
+[^464]: NYTimes, Lost Passwords Lock Millionaires Out of Their Bitcoin Fortunes, <https://www.nytimes.com/2021/01/12/technology/bitcoin-passwords-wallets-fortunes.html> <sup>[[Archive.org]][1106]</sup>
 
-[^465]: CrystalDiskInfo <https://crystalmark.info/en/software/crystaldiskinfo/> <sup>[[Archive.org]][1286]</sup>
+[^465]: CrystalDiskInfo, <https://crystalmark.info/en/software/crystaldiskinfo/> <sup>[[Archive.org]][1286]</sup>
 
 [^466]: Wikipedia, Faraday Cage, <https://en.wikipedia.org/wiki/Faraday_cage> <sup>[[Wikiless]][1287]</sup> <sup>[[Archive.org]][1288]</sup>
 
-[^467]: Edith Cowan University, A forensic examination of several mobile device Faraday bags & materials to test their effectiveness materials to test their effectiveness <https://ro.ecu.edu.au/cgi/viewcontent.cgi?article=1165&context=adf> <sup>[[Archive.org]][1289]</sup>
+[^467]: Edith Cowan University, A forensic examination of several mobile device Faraday bags & materials to test their effectiveness materials to test their effectiveness, <https://ro.ecu.edu.au/cgi/viewcontent.cgi?article=1165&context=adf> <sup>[[Archive.org]][1289]</sup>
 
-[^468]: arXiv, Deep-Spying: Spying using Smartwatch and Deep Learning <https://arxiv.org/pdf/1512.05616.pdf> <sup>[[Archive.org]][1290]</sup>
+[^468]: arXiv, Deep-Spying: Spying using Smartwatch and Deep Learning, <https://arxiv.org/pdf/1512.05616.pdf> <sup>[[Archive.org]][1290]</sup>
 
-[^469]: Acm.org, Privacy Implications of Accelerometer Data: A Review of Possible Inferences <https://dl.acm.org/doi/pdf/10.1145/3309074.3309076> <sup>[[Archive.org]][1291]</sup>
+[^469]: Acm.org, Privacy Implications of Accelerometer Data: A Review of Possible Inferences, <https://dl.acm.org/doi/pdf/10.1145/3309074.3309076> <sup>[[Archive.org]][1291]</sup>
 
-[^470]: YouTube, Fingerprinting Paper - Forensic Education <https://www.youtube.com/watch?v=sO98kDLkh-M> <sup>[[Invidious]][1292]</sup>
+[^470]: YouTube, Fingerprinting Paper - Forensic Education, <https://www.youtube.com/watch?v=sO98kDLkh-M> <sup>[[Invidious]][1292]</sup>
 
 [^471]: Wikipedia, Touch DNA, <https://en.wikipedia.org/wiki/Touch_DNA> <sup>[[Wikiless]][1293]</sup> <sup>[[Archive.org]][1294]</sup>
 
-[^472]: TheDNAGuide, DNA from Postage Stamps or Hair Samples? Yeeesssss..... <https://www.yourdnaguide.com/ydgblog/dna-hair-samples-postage-stamps> <sup>[[Archive.org]][1295]</sup>
+[^472]: TheDNAGuide, DNA from Postage Stamps or Hair Samples? Yeeesssss....., <https://www.yourdnaguide.com/ydgblog/dna-hair-samples-postage-stamps> <sup>[[Archive.org]][1295]</sup>
 
-[^473]: GitHub, Mhinkie, OONI-Detection <https://github.com/mhinkie/ooni-detection> <sup>[[Archive.org]][1296]</sup>
+[^473]: GitHub, Mhinkie, OONI-Detection, <https://github.com/mhinkie/ooni-detection> <sup>[[Archive.org]][1296]</sup>
 
-[^474]: Wikipedia, File Verification <https://en.wikipedia.org/wiki/File_verification> <sup>[[Wikiless]][1297]</sup> <sup>[[Archive.org]][1298]</sup>
+[^474]: Wikipedia, File Verification, <https://en.wikipedia.org/wiki/File_verification> <sup>[[Wikiless]][1297]</sup> <sup>[[Archive.org]][1298]</sup>
 
-[^475]: Wikipedia, CRC <https://en.wikipedia.org/wiki/Cyclic_redundancy_check> <sup>[[Wikiless]][1299]</sup> <sup>[[Archive.org]][1300]</sup>
+[^475]: Wikipedia, CRC, <https://en.wikipedia.org/wiki/Cyclic_redundancy_check> <sup>[[Wikiless]][1299]</sup> <sup>[[Archive.org]][1300]</sup>
 
-[^476]: Wikipedia, MD5 <https://en.wikipedia.org/wiki/MD5> <sup>[[Wikiless]][1301]</sup> <sup>[[Archive.org]][1302]</sup>
+[^476]: Wikipedia, MD5, <https://en.wikipedia.org/wiki/MD5> <sup>[[Wikiless]][1301]</sup> <sup>[[Archive.org]][1302]</sup>
 
-[^477]: Wikipedia, MD5 Security <https://en.wikipedia.org/wiki/MD5#Security> <sup>[[Wikiless]][1301]</sup> <sup>[[Archive.org]][1302]</sup>
+[^477]: Wikipedia, MD5 Security, <https://en.wikipedia.org/wiki/MD5#Security> <sup>[[Wikiless]][1301]</sup> <sup>[[Archive.org]][1302]</sup>
 
-[^478]: Wikipedia, Collisions <https://en.wikipedia.org/wiki/Collision_(computer_science)> <sup>[[Wikiless]][1303]</sup> <sup>[[Archive.org]][1304]</sup>
+[^478]: Wikipedia, Collisions, <https://en.wikipedia.org/wiki/Collision_(computer_science)> <sup>[[Wikiless]][1303]</sup> <sup>[[Archive.org]][1304]</sup>
 
-[^479]: Wikipedia, SHA <https://en.wikipedia.org/wiki/Secure_Hash_Algorithms> <sup>[[Wikiless]][1305]</sup> <sup>[[Archive.org]][1306]</sup>
+[^479]: Wikipedia, SHA, <https://en.wikipedia.org/wiki/Secure_Hash_Algorithms> <sup>[[Wikiless]][1305]</sup> <sup>[[Archive.org]][1306]</sup>
 
-[^480]: Wikipedia, SHA-2 <https://en.wikipedia.org/wiki/SHA-2> <sup>[[Wikiless]][1307]</sup> <sup>[[Archive.org]][1308]</sup>
+[^480]: Wikipedia, SHA-2, <https://en.wikipedia.org/wiki/SHA-2> <sup>[[Wikiless]][1307]</sup> <sup>[[Archive.org]][1308]</sup>
 
-[^481]: Wikipedia, Collision Resistance <https://en.wikipedia.org/wiki/Collision_resistance> <sup>[[Wikiless]][1309]</sup> <sup>[[Archive.org]][1310]</sup>
+[^481]: Wikipedia, Collision Resistance, <https://en.wikipedia.org/wiki/Collision_resistance> <sup>[[Wikiless]][1309]</sup> <sup>[[Archive.org]][1310]</sup>
 
-[^482]: GnuPG Gpg4win Wiki, Check integrity of Gpg4win packages <https://wiki.gnupg.org/Gpg4win/CheckIntegrity> <sup>[[Archive.org]][1311]</sup>
+[^482]: GnuPG Gpg4win Wiki, Check integrity of Gpg4win packages, <https://wiki.gnupg.org/Gpg4win/CheckIntegrity> <sup>[[Archive.org]][1311]</sup>
 
-[^483]: Medium.com, How to verify checksum on Mac <https://medium.com/@EvgeniIvanov/how-to-verify-checksum-on-mac-988f166b0c4f> <sup>[[Scribe.rip]][1312]</sup> <sup>[[Archive.org]][1313]</sup>
+[^483]: Medium.com, How to verify checksum on Mac, <https://medium.com/@EvgeniIvanov/how-to-verify-checksum-on-mac-988f166b0c4f> <sup>[[Scribe.rip]][1312]</sup> <sup>[[Archive.org]][1313]</sup>
 
-[^484]: Wikipedia, GPG <https://en.wikipedia.org/wiki/GNU_Privacy_Guard> <sup>[[Wikiless]][1314]</sup> <sup>[[Archive.org]][1315]</sup>
+[^484]: Wikipedia, GPG, <https://en.wikipedia.org/wiki/GNU_Privacy_Guard> <sup>[[Wikiless]][1314]</sup> <sup>[[Archive.org]][1315]</sup>
 
-[^485]: Wikipedia, Public-Key Cryptography <https://en.wikipedia.org/wiki/Public-key_cryptography> <sup>[[Wikiless]][1316]</sup> <sup>[[Archive.org]][1317]</sup>
+[^485]: Wikipedia, Public-Key Cryptography, <https://en.wikipedia.org/wiki/Public-key_cryptography> <sup>[[Wikiless]][1316]</sup> <sup>[[Archive.org]][1317]</sup>
 
-[^486]: Wikipedia, Polymorphic Code <https://en.wikipedia.org/wiki/Polymorphic_code> <sup>[[Wikiless]][1318]</sup> <sup>[[Archive.org]][1319]</sup>
+[^486]: Wikipedia, Polymorphic Code, <https://en.wikipedia.org/wiki/Polymorphic_code> <sup>[[Wikiless]][1318]</sup> <sup>[[Archive.org]][1319]</sup>
 
 [^487]: Whonix Documentation, Use of AV, <https://www.whonix.org/wiki/Malware_and_Firmware_Trojans#The_Utility_of_Antivirus_Tools> <sup>[[Archive.org]][1320]</sup>
 
@@ -13045,19 +13045,19 @@ You can find some introduction on these on these projects:
 
 [^489]: AV-Test Security Report 2018-2019, <https://www.av-test.org/fileadmin/pdf/security_report/AV-TEST_Security_Report_2018-2019.pdf> <sup>[[Archive.org]][1322]</sup>
 
-[^490]: ZDNet, ESET discovers 21 new Linux malware families <https://www.zdnet.com/article/eset-discovers-21-new-linux-malware-families/> <sup>[[Archive.org]][1323]</sup>
+[^490]: ZDNet, ESET discovers 21 new Linux malware families, <https://www.zdnet.com/article/eset-discovers-21-new-linux-malware-families/> <sup>[[Archive.org]][1323]</sup>
 
-[^491]: NakeSecurity, EvilGnome -- Linux malware aimed at your desktop, not your servers <https://nakedsecurity.sophos.com/2019/07/25/evilgnome-linux-malware-aimed-at-your-laptop-not-your-servers/> <sup>[[Archive.org]][1324]</sup>
+[^491]: NakeSecurity, EvilGnome -- Linux malware aimed at your desktop, not your servers, <https://nakedsecurity.sophos.com/2019/07/25/evilgnome-linux-malware-aimed-at-your-laptop-not-your-servers/> <sup>[[Archive.org]][1324]</sup>
 
-[^492]: Immunify, HiddenWasp: How to detect malware hidden on Linux & IoT <https://blog.imunify360.com/hiddenwasp-how-to-detect-malware-hidden-on-linux-iot> <sup>[[Archive.org]][1325]</sup>
+[^492]: Immunify, HiddenWasp: How to detect malware hidden on Linux & IoT, <https://blog.imunify360.com/hiddenwasp-how-to-detect-malware-hidden-on-linux-iot> <sup>[[Archive.org]][1325]</sup>
 
-[^493]: Wikipedia, Linux Malware <https://en.wikipedia.org/wiki/Linux_malware> <sup>[[Wikiless]][1326]</sup> <sup>[[Archive.org]][1327]</sup>
+[^493]: Wikipedia, Linux Malware, <https://en.wikipedia.org/wiki/Linux_malware> <sup>[[Wikiless]][1326]</sup> <sup>[[Archive.org]][1327]</sup>
 
-[^494]: Wikipedia, macOS Malware <https://en.wikipedia.org/wiki/macOS_malware> <sup>[[Wikiless]][1328]</sup> <sup>[[Archive.org]][1329]</sup>
+[^494]: Wikipedia, macOS Malware, <https://en.wikipedia.org/wiki/macOS_malware> <sup>[[Wikiless]][1328]</sup> <sup>[[Archive.org]][1329]</sup>
 
-[^495]: MacWorld, List of Mac viruses, malware and security flaws <https://www.macworld.co.uk/feature/mac-viruses-list-3668354/> <sup>[[Archive.org]][1330]</sup>
+[^495]: MacWorld, List of Mac viruses, malware and security flaws, <https://www.macworld.co.uk/feature/mac-viruses-list-3668354/> <sup>[[Archive.org]][1330]</sup>
 
-[^496]: JAMF, The Mac Malware of 2020 <https://resources.jamf.com/documents/macmalware-2020.pdf> <sup>[[Archive.org]][1331]</sup>
+[^496]: JAMF, The Mac Malware of 2020, <https://resources.jamf.com/documents/macmalware-2020.pdf> <sup>[[Archive.org]][1331]</sup>
 
 [^497]: macOS Security and Privacy Guide, <https://github.com/drduh/macOS-Security-and-Privacy-Guide#viruses-and-malware> <sup>[[Archive.org]][294]</sup>
 
@@ -13067,75 +13067,75 @@ You can find some introduction on these on these projects:
 
 [^500]: Oracle Virtualbox Documentation, <https://docs.oracle.com/en/virtualization/virtualbox/6.0/admin/hyperv-support.html> <sup>[[Archive.org]][1333]</sup>
 
-[^501]: Lenny Zeltser, Analyzing Malicious Documents Cheat Sheet <https://zeltser.com/analyzing-malicious-documents/> <sup>[[Archive.org]][1334]</sup>
+[^501]: Lenny Zeltser, Analyzing Malicious Documents Cheat Sheet, <https://zeltser.com/analyzing-malicious-documents/> <sup>[[Archive.org]][1334]</sup>
 
-[^502]: Wikipedia, Portable Applications <https://en.wikipedia.org/wiki/Portable_application> <sup>[[Wikiless]][1335]</sup> <sup>[[Archive.org]][1336]</sup>
+[^502]: Wikipedia, Portable Applications, <https://en.wikipedia.org/wiki/Portable_application> <sup>[[Wikiless]][1335]</sup> <sup>[[Archive.org]][1336]</sup>
 
-[^503]: Brave Help, What is a Private Window with Tor Connectivity? <https://support.brave.com/hc/en-us/articles/360018121491-What-is-a-Private-Window-with-Tor> <sup>[[Archive.org]][1279]</sup>
+[^503]: Brave Help, What is a Private Window with Tor Connectivity?, <https://support.brave.com/hc/en-us/articles/360018121491-What-is-a-Private-Window-with-Tor> <sup>[[Archive.org]][1279]</sup>
 
-[^504]: BlackGNU, Brave, the false sensation of privacy <https://blackgnu.net/brave-is-shit.html> <sup>[[Archive.org]][1337]</sup>
+[^504]: BlackGNU, Brave, the false sensation of privacy, <https://blackgnu.net/brave-is-shit.html> <sup>[[Archive.org]][1337]</sup>
 
-[^505]: Brave Help Center, What is "Shields"? <https://support.brave.com/hc/en-us/articles/360022973471-What-is-Shields> <sup>[[Archive.org]][1338]</sup>
+[^505]: Brave Help Center, What is "Shields"?, <https://support.brave.com/hc/en-us/articles/360022973471-What-is-Shields> <sup>[[Archive.org]][1338]</sup>
 
-[^506]: VentureBeat, Browser benchmark battle January 2020: Chrome vs. Firefox vs. Edge vs. Brave <https://venturebeat.com/2020/01/15/browser-benchmark-battle-january-2020-chrome-firefox-edge-brave/view-all/> <sup>[[Archive.org]][1339]</sup>
+[^506]: VentureBeat, Browser benchmark battle January 2020: Chrome vs. Firefox vs. Edge vs. Brave, <https://venturebeat.com/2020/01/15/browser-benchmark-battle-january-2020-chrome-firefox-edge-brave/view-all/> <sup>[[Archive.org]][1339]</sup>
 
-[^507]: Brave.com, Brave, Fingerprinting, and Privacy Budgets <https://brave.com/brave-fingerprinting-and-privacy-budgets/> <sup>[[Archive.org]][159]</sup>
+[^507]: Brave.com, Brave, Fingerprinting, and Privacy Budgets, <https://brave.com/brave-fingerprinting-and-privacy-budgets/> <sup>[[Archive.org]][159]</sup>
 
-[^508]: Madaidan's Insecurities, Firefox and Chromium <https://madaidans-insecurities.github.io/firefox-chromium.html> <sup>[[Archive.org]][1340]</sup>
+[^508]: Madaidan's Insecurities, Firefox and Chromium, <https://madaidans-insecurities.github.io/firefox-chromium.html> <sup>[[Archive.org]][1340]</sup>
 
-[^509]: GrapheneOS, Web Browsing <https://grapheneos.org/usage#web-browsing> <sup>[[Archive.org]][1341]</sup>
+[^509]: GrapheneOS, Web Browsing, <https://grapheneos.org/usage#web-browsing> <sup>[[Archive.org]][1341]</sup>
 
-[^510]: ResearchGate, Web Browser Privacy: What Do Browsers Say When They Phone Home? <https://www.researchgate.net/publication/349979628_Web_Browser_Privacy_What_Do_Browsers_Say_When_They_Phone_Home> <sup>[[Archive.org]][1342]</sup>
+[^510]: ResearchGate, Web Browser Privacy: What Do Browsers Say When They Phone Home?, <https://www.researchgate.net/publication/349979628_Web_Browser_Privacy_What_Do_Browsers_Say_When_They_Phone_Home> <sup>[[Archive.org]][1342]</sup>
 
-[^511]: Duck's pond, Ungoogled-Chromium <https://qua3k.github.io/ungoogled/> <sup>[[Archive.org]][1343]</sup>
+[^511]: Duck's pond, Ungoogled-Chromium, <https://qua3k.github.io/ungoogled/> <sup>[[Archive.org]][1343]</sup>
 
-[^512]: Madaidan's Insecurities, Firefox and Chromium <https://madaidans-insecurities.github.io/firefox-chromium.html> <sup>[[Archive.org]][1340]</sup>
+[^512]: Madaidan's Insecurities, Firefox and Chromium, <https://madaidans-insecurities.github.io/firefox-chromium.html> <sup>[[Archive.org]][1340]</sup>
 
-[^513]: GrapheneOS, Web Browsing <https://grapheneos.org/usage#web-browsing> <sup>[[Archive.org]][1341]</sup>
+[^513]: GrapheneOS, Web Browsing, <https://grapheneos.org/usage#web-browsing> <sup>[[Archive.org]][1341]</sup>
 
-[^514]: Microsoft.com, Microsoft Edge support for Microsoft Defender Application Guard <https://docs.microsoft.com/en-us/deployedge/microsoft-edge-security-windows-defender-application-guard> <sup>[[Archive.org]][1344]</sup>
+[^514]: Microsoft.com, Microsoft Edge support for Microsoft Defender Application Guard, <https://docs.microsoft.com/en-us/deployedge/microsoft-edge-security-windows-defender-application-guard> <sup>[[Archive.org]][1344]</sup>
 
-[^515]: PcMag, Mozilla Signs Lucrative 3-Year Google Search Deal for Firefox <https://www.pcmag.com/news/mozilla-signs-lucrative-3-year-google-search-deal-for-firefox> <sup>[[Archive.org]][1345]</sup>
+[^515]: PcMag, Mozilla Signs Lucrative 3-Year Google Search Deal for Firefox, <https://www.pcmag.com/news/mozilla-signs-lucrative-3-year-google-search-deal-for-firefox> <sup>[[Archive.org]][1345]</sup>
 
-[^516]: Madaidan's Insecurities, Firefox and Chromium <https://madaidans-insecurities.github.io/firefox-chromium.html> <sup>[[Archive.org]][1340]</sup>
+[^516]: Madaidan's Insecurities, Firefox and Chromium, <https://madaidans-insecurities.github.io/firefox-chromium.html> <sup>[[Archive.org]][1340]</sup>
 
-[^517]: FingerprintJS, Demo: Disabling JavaScript Won't Save You from Fingerprinting <https://fingerprintjs.com/blog/disabling-javascript-wont-stop-fingerprinting/> <sup>[[Archive.org]][933]</sup>
+[^517]: FingerprintJS, Demo: Disabling JavaScript Won't Save You from Fingerprinting, <https://fingerprintjs.com/blog/disabling-javascript-wont-stop-fingerprinting/> <sup>[[Archive.org]][933]</sup>
 
-[^518]: Duck's pond, Ungoogled-Chromium <https://qua3k.github.io/ungoogled/> <sup>[[Archive.org]][1343]</sup>
+[^518]: Duck's pond, Ungoogled-Chromium, <https://qua3k.github.io/ungoogled/> <sup>[[Archive.org]][1343]</sup>
 
-[^519]: Wikipedia, Virtualization <https://en.wikipedia.org/wiki/Virtualization> <sup>[[Wikiless]][1346]</sup> <sup>[[Archive.org]][1347]</sup>
+[^519]: Wikipedia, Virtualization, <https://en.wikipedia.org/wiki/Virtualization> <sup>[[Wikiless]][1346]</sup> <sup>[[Archive.org]][1347]</sup>
 
-[^520]: Tor Project, Project Snowflake <https://snowflake.torproject.org/> <sup>[[Archive.org]][563]</sup>
+[^520]: Tor Project, Project Snowflake, <https://snowflake.torproject.org/> <sup>[[Archive.org]][563]</sup>
 
-[^521]: GitHub, Obfs4 Repository <https://github.com/Yawning/obfs4/> <sup>[[Archive.org]][1348]</sup>
+[^521]: GitHub, Obfs4 Repository, <https://github.com/Yawning/obfs4/> <sup>[[Archive.org]][1348]</sup>
 
-[^522]: Tor Browser Manual, Pluggable Transport <https://tb-manual.torproject.org/circumvention/> <sup>[[Archive.org]][1349]</sup>
+[^522]: Tor Browser Manual, Pluggable Transport, <https://tb-manual.torproject.org/circumvention/> <sup>[[Archive.org]][1349]</sup>
 
-[^523]: Tor Browser Manual, Pluggable Transport <https://tb-manual.torproject.org/circumvention/> <sup>[[Archive.org]][1349]</sup>
+[^523]: Tor Browser Manual, Pluggable Transport, <https://tb-manual.torproject.org/circumvention/> <sup>[[Archive.org]][1349]</sup>
 
-[^524]: Wikipedia, Domain Fronting <https://en.wikipedia.org/wiki/Domain_fronting> <sup>[[Wikiless]][1350]</sup> <sup>[[Archive.org]][1351]</sup>
+[^524]: Wikipedia, Domain Fronting, <https://en.wikipedia.org/wiki/Domain_fronting> <sup>[[Wikiless]][1350]</sup> <sup>[[Archive.org]][1351]</sup>
 
-[^525]: GitLab, Tor Browser Issues, Add uBlock Origin to the Tor Browser <https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/17569> <sup>[[Archive.org]][1352]</sup>
+[^525]: GitLab, Tor Browser Issues, Add uBlock Origin to the Tor Browser, <https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/17569> <sup>[[Archive.org]][1352]</sup>
 
-[^526]: Vice, The NSA and CIA Use Ad Blockers Because Online Advertising Is So Dangerous <https://www.vice.com/en/article/93ypke/the-nsa-and-cia-use-ad-blockers-because-online-advertising-is-so-dangerous> <sup>[[Archive.org]][1353]</sup>
+[^526]: Vice, The NSA and CIA Use Ad Blockers Because Online Advertising Is So Dangerous, <https://www.vice.com/en/article/93ypke/the-nsa-and-cia-use-ad-blockers-because-online-advertising-is-so-dangerous> <sup>[[Archive.org]][1353]</sup>
 
-[^527]: Europol, Wasabi Wallet Report <https://www.tbstat.com/wp/uploads/2020/06/Europol-Wasabi-Wallet-Report.pdf> <sup>[[Archive.org]][1354]</sup>
+[^527]: Europol, Wasabi Wallet Report, <https://www.tbstat.com/wp/uploads/2020/06/Europol-Wasabi-Wallet-Report.pdf> <sup>[[Archive.org]][1354]</sup>
 
-[^528]: NIST, NIST Has Spoken - Death to Complexity, Long Live the Passphrase! <https://www.sans.org/blog/nist-has-spoken-death-to-complexity-long-live-the-passphrase/> <sup>[[Archive.org]][1355]</sup>
+[^528]: NIST, NIST Has Spoken - Death to Complexity, Long Live the Passphrase!, <https://www.sans.org/blog/nist-has-spoken-death-to-complexity-long-live-the-passphrase/> <sup>[[Archive.org]][1355]</sup>
 
-[^529]: ZDnet, FBI recommends passphrases over password complexity <https://www.zdnet.com/article/fbi-recommends-passphrases-over-password-complexity/> <sup>[[Archive.org]][1356]</sup>
+[^529]: ZDnet, FBI recommends passphrases over password complexity, <https://www.zdnet.com/article/fbi-recommends-passphrases-over-password-complexity/> <sup>[[Archive.org]][1356]</sup>
 
-[^530]: The Intercept, Passphrases That You Can Memorize --- But That Even the NSA Can't Guess <https://theintercept.com/2015/03/26/passphrases-can-memorize-attackers-cant-guess/> <sup>[[Tor Mirror]][1357]</sup> <sup>[[Archive.org]][1358]</sup>
+[^530]: The Intercept, Passphrases That You Can Memorize --- But That Even the NSA Can't Guess, <https://theintercept.com/2015/03/26/passphrases-can-memorize-attackers-cant-guess/> <sup>[[Tor Mirror]][1357]</sup> <sup>[[Archive.org]][1358]</sup>
 
-[^531]: ProtonMail Blog, Let's settle the password vs. passphrase debate once and for all <https://protonmail.com/blog/protonmail-com-blog-password-vs-passphrase/> <sup>[[Archive.org]][1359]</sup>
+[^531]: ProtonMail Blog, Let's settle the password vs. passphrase debate once and for all, <https://protonmail.com/blog/protonmail-com-blog-password-vs-passphrase/> <sup>[[Archive.org]][1359]</sup>
 
-[^532]: YouTube, Edward Snowden on Passwords: Last Week Tonight with John Oliver (HBO) <https://www.youtube.com/watch?v=yzGzB-yYKcc> <sup>[[Invidious]][1360]</sup>
+[^532]: YouTube, Edward Snowden on Passwords: Last Week Tonight with John Oliver (HBO), <https://www.youtube.com/watch?v=yzGzB-yYKcc> <sup>[[Invidious]][1360]</sup>
 
-[^533]: YouTube, How to Choose a Password -- Computerphile <https://www.youtube.com/watch?v=3NjQ9b3pgIg> <sup>[[Invidious]][699]</sup>
+[^533]: YouTube, How to Choose a Password -- Computerphile, <https://www.youtube.com/watch?v=3NjQ9b3pgIg> <sup>[[Invidious]][699]</sup>
 
-[^534]: Wikipedia, Passphrase <https://en.wikipedia.org/wiki/Passphrase#Passphrase_selection> <sup>[[Wikiless]][1361]</sup> <sup>[[Archive.org]][1362]</sup>
+[^534]: Wikipedia, Passphrase, <https://en.wikipedia.org/wiki/Passphrase#Passphrase_selection> <sup>[[Wikiless]][1361]</sup> <sup>[[Archive.org]][1362]</sup>
 
-[^535]: Monero Research Lab, Evaluating cryptocurrency security and privacy in a post-quantum world <https://github.com/insight-decentralized-consensus-lab/post-quantum-monero/blob/master/writeups/technical_note.pdf> <sup>[[Archive.org]][1363]</sup>
+[^535]: Monero Research Lab, Evaluating cryptocurrency security and privacy in a post-quantum world, <https://github.com/insight-decentralized-consensus-lab/post-quantum-monero/blob/master/writeups/technical_note.pdf> <sup>[[Archive.org]][1363]</sup>
 
   [Contents:]: #contents
   [Pre-requisites and limitations:]: #pre-requisites-and-limitations


### PR DESCRIPTION
That's it, that's the only change but there are 489 lines changed.

` <https:` to `, <https:` then change all double commas to single comma via regex. 
There was probably an easier regex command but I don't mind this way.