### PR TITLE
[WIP] Qubes route updates

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -5282,11 +5282,11 @@ See: [Appendix V: What browser to use in your Guest VM/Disposable VM]
 
 #### Fedora Disposable VM:
 
-Within the Applications Menu (upper left), Select the Fedora-3x template (x being the latest Fedora template available in your install):
+Within the Applications Menu (upper left), Select the Fedora-33 template (x being the latest Fedora template available in your install):
 
 -   Go into Qube Settings
 
--   Clone the VM and name it "fedora-3x-brave" (this VM template will have Brave)
+-   Clone the VM and name it "fedora-32-brave" (this VM template will have Brave)
 
 -   Again, go into the Applications Menu and select the clone you just created
 

--- a/guide.md
+++ b/guide.md
@@ -5070,7 +5070,7 @@ This is based on the tutorial provided by Qubes OS themselves (<https://github.c
 
 -   Select Type: Standalone Qube copied from a template
 
--   Select Template: Debian-10 (or Debian-11 if you already have it installed)
+-   Select Template: Debian-11 (the default)
 
 -   Select Networking:
 

--- a/guide.md
+++ b/guide.md
@@ -5514,7 +5514,7 @@ Keep in mind that those do not provide a zero-access design (meaning they can ac
 #### A note about Riseup:
 
 RiseUp's warrant canary has been renewed late, with their Twitter posting a cryptic message seeming to tell users not to trust them.
-Due to the suspicious situation, this guide can no longer recommend them.
+Due to the suspicious situation, this guide can no longer recommend them. The collective updated their Warrant Canary[^283] on May 1, 2022 with no explanation to their cryptic tweet about songbirds or why it took so long to update.
 
 *Also see: <https://forums.whonix.org/t/riseup-net-likely-compromised/3195>*
 

--- a/guide.md
+++ b/guide.md
@@ -5514,7 +5514,7 @@ Keep in mind that those do not provide a zero-access design (meaning they can ac
 #### A note about Riseup:
 
 RiseUp's warrant canary has been renewed late, with their Twitter posting a cryptic message seeming to tell users not to trust them.
-Due to the suspicious situation, this guide can no longer recommend them. The collective updated their Warrant Canary[^283] on May 1, 2022 with no explanation to their cryptic tweet about songbirds or why it took so long to update.
+Due to the suspicious situation, this guide can no longer recommend them.
 
 *Also see: <https://forums.whonix.org/t/riseup-net-likely-compromised/3195>*
 


### PR DESCRIPTION
### Update for Qubes route 

Keeping things as updated as possible. No notable changes aside from software versions and the actual 4.1.x upgrade. The rest can all be considered up-to-date. Be sure to check the digest file you download with the Qubes ISO. Android VM setup may have changed but not technically, only graphically. The Whonix installation also has different names for the LUKS partitioning button but it isn't something major so it's not necessary to update it here. Finally, a note on Riseup updating their canary, for what that's worth, I included it in this PR because it's VPN-related and users should know about the canary update for transparency. Like I said, for what it's worth, they did update the canary on May 1st, but they never explained the cryptic messages on Twitter.