### PR TITLE
Proposals: new temporary general rule, temporary removal of PSA Ban Appeals

### DIFF
--- a/chatrooms-rules.md
+++ b/chatrooms-rules.md
@@ -29,6 +29,7 @@ These are currently only enforced on **Anonymity** and **Security**, and not app
 - No upload of any non-media files (binaries, executables, compressed files...)
 - No voice messages (these will be auto-deleted by the bots)
 - **Avoid drifting too much off-topic or move to an off-topic room like #bnonymity**
+- **Any discussion about AnonyPla / Lena whereabouts will not be tolerated in #Anonymity, #Security, and ##psa-ot rooms. You may discuss this in the #Bnonymity room. If you do not respect this rule, you will risk being warned, kicked or even banned depending on the circumstances.
 
 Some exceptions can apply, see the [exceptions](#exceptions) section at the bottom of this page.
 
@@ -72,5 +73,4 @@ Currently, the following rooms are sharing a common PSA banlist for serious offe
 This means that those PSA bans are effectively applied on all those rooms and can be issued by admins of these rooms. See the next section for information about appeals.
 
 #### Ban Appeals:<a name="appeals"></a>
-- **If your ban is a local ban issued by room moderators of a specific room: please contact the mods of the room in question to state your case for appealing. PSA Admins cannot and will not assist you with local bans.**
-- If your ban is a PSA ban (usually formatted as: "date, reason, appeal status") and you are banned on several PSA rooms: please send an e-mail to <appeal@psa.aleeas.com> to state your case for appealing. This will notify the admins who can assess your appeal.
+- **Please contact the mods or admins of the room in question to state your case for appealing.**

--- a/chatrooms-rules.md
+++ b/chatrooms-rules.md
@@ -29,7 +29,7 @@ These are currently only enforced on **Anonymity** and **Security**, and not app
 - No upload of any non-media files (binaries, executables, compressed files...)
 - No voice messages (these will be auto-deleted by the bots)
 - **Avoid drifting too much off-topic or move to an off-topic room like #bnonymity**
-- **Any discussion about AnonyPla / Lena whereabouts will not be tolerated in #Anonymity, #Security, and ##psa-ot rooms. You may discuss this in the #Bnonymity room. If you do not respect this rule, you will risk being warned, kicked or even banned depending on the circumstances.
+- **Any discussion about AnonyPla / Lena whereabouts is only tolerated, to an extent, in the #Bnonymity room.**
 
 Some exceptions can apply, see the [exceptions](#exceptions) section at the bottom of this page.
 

--- a/chatrooms-rules.md
+++ b/chatrooms-rules.md
@@ -31,7 +31,7 @@ These are currently only enforced on **Anonymity** and **Security**, and not app
 - **Avoid drifting too much off-topic or move to an off-topic room like #bnonymity**
 - **Any discussion about AnonyPla / Lena whereabouts is only tolerated, to an extent, in the #Bnonymity room.**
 
-Some exceptions can apply, see the [exceptions](#exceptions) section at the bottom of this page.
+Some exceptions can apply, see the [exceptions](#exceptions) section at the bottom of this page. Violations will be handled at the discretion of the acting moderator.
 
 #### Rules for Nothing To Hide Privacy:<a name="nth"></a>
 - Zero tolerance for discussion of how to commit illicit acts
@@ -53,7 +53,7 @@ See <https://artemislena.eu/coc.html>
 - No hate speech (No racism, no homophobia, no transphobia...)
 - No spammerino (scams, ads, flooding...)
 - No doxxing
-- No Porn, no Gore, no Hentai...
+- No NSFW content (no Porn, no Gore, no Hentai...)
 - All of the above can result in an insta-ban depending on the severity
 
 #### Exceptions:<a name="exceptions"></a>


### PR DESCRIPTION
- Proposal, new special specific targeted **temporary (until the situation normalize)** rule due to the amount of issues/drama we have with this: 
    - **Forbid all discussions about AnonyPla / Lena whereabouts in all rooms (Anonymity, Security, and PSA off-topic) except #Bnonymity. Transgressing the rule might lead to a warning, a kick, or a ban in all the rooms above depending on the circumstances.**
- Temporary removal of PSA ban appeals since the e-mail doesn't work anymore **(tested)** until we find another solution.

I know the rule proposal is redundant but it's just to "hammer the nail in their head" and make it super clear: >> #bnonymity or face the consequences.

Back to being an on-topic room. Welcoming and without the drama. 